### PR TITLE
Add support for unit tests with an example.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.*proj.user
 *.DotSettings.user
 *.userprefs
+/_ReSharper.Caches

--- a/MetaBrainz.MusicBrainz.Tests/BrowseTests.cs
+++ b/MetaBrainz.MusicBrainz.Tests/BrowseTests.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using FluentAssertions;
+
+using Xunit;
+
+namespace MetaBrainz.MusicBrainz.Tests {
+  public class BrowseTests : MusicBrainzTest {
+
+    private const string ReleaseTestData = @"{
+   ""releases"":[
+      {
+         ""packaging"":null,
+         ""title"":""Flying in a Blue Dream"",
+         ""asin"":null,
+         ""country"":""US"",
+         ""status"":""Official"",
+         ""barcode"":""088561101541"",
+         ""id"":""296c4baa-4a13-3623-b526-7e7b35c8dfac"",
+         ""packaging-id"":null,
+         ""cover-art-archive"":{
+            ""darkened"":false,
+            ""artwork"":false,
+            ""back"":false,
+            ""count"":0,
+            ""front"":false
+         },
+         ""disambiguation"":"""",
+         ""release-events"":[
+            {
+               ""date"":""1989-10-30"",
+               ""area"":{
+                  ""iso-3166-1-codes"":[
+                     ""US""
+                  ],
+                  ""id"":""489ce91b-6658-3307-9877-795b68554c98"",
+                  ""name"":""United States"",
+                  ""disambiguation"":"""",
+                  ""sort-name"":""United States"",
+                  ""type-id"":null,
+                  ""type"":null
+               }
+            }
+         ],
+         ""date"":""1989-10-30"",
+         ""quality"":""normal"",
+         ""status-id"":""4e304316-386d-3409-af2e-78857eec5cfe"",
+         ""text-representation"":{
+            ""language"":""eng"",
+            ""script"":""Latn""
+         }
+      }
+   ],
+   ""release-count"":1,
+   ""release-offset"":0
+}";
+
+
+    [Fact]
+    public async Task CanBrowseArtistReleases() {
+      
+      var query = new Query(this.CreateMockWebClient(BrowseTests.ReleaseTestData));
+      var releases = await query.BrowseArtistReleasesAsync(Guid.Empty).ConfigureAwait(false);
+      releases.Results.Should().HaveCount(1);
+      releases.TotalResults.Should().Be(1);
+      releases.UnhandledProperties.Should().BeNullOrEmpty();
+      var release = releases.Results.Single();
+      release.Should().NotBeNull();
+      release.Title.Should().Be("Flying in a Blue Dream");
+    }
+
+  }
+
+}

--- a/MetaBrainz.MusicBrainz.Tests/MetaBrainz.MusicBrainz.Tests.csproj
+++ b/MetaBrainz.MusicBrainz.Tests/MetaBrainz.MusicBrainz.Tests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Moq" Version="4.14.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.2.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\MetaBrainz.MusicBrainz\MetaBrainz.MusicBrainz.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/MetaBrainz.MusicBrainz.Tests/MusicBrainzTest.cs
+++ b/MetaBrainz.MusicBrainz.Tests/MusicBrainzTest.cs
@@ -1,0 +1,62 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Moq;
+using Moq.Protected;
+
+namespace MetaBrainz.MusicBrainz.Tests
+{
+
+  public class MusicBrainzTest {
+
+    protected WebClient CreateMockWebClient(string responseText) {
+      var webClient = new Mock<WebClient> { CallBase = true };
+      webClient
+        .Protected()
+        .Setup<WebRequest>("GetWebRequest", ItExpr.IsAny<Uri>())
+        .Returns<Uri>(uri => MusicBrainzTest.CreateMockWebRequest(responseText));
+      return webClient.Object;
+    }
+
+    private static WebRequest CreateMockWebRequest(string responseText) {
+      var webResponse = new Mock<WebResponse>();
+
+      webResponse
+        .SetupGet(x => x.ContentLength)
+        .Returns(responseText.Length);
+      webResponse
+        .Setup(x => x.GetResponseStream())
+        .Returns(() => new MemoryStream(Encoding.UTF8.GetBytes(responseText)));
+
+
+      var webRequest = new Mock<WebRequest>();
+      webRequest
+        .Setup(x => x.GetResponse())
+        .Returns(() => webResponse.Object);
+
+      webRequest
+        .Setup(x => x.BeginGetResponse(It.IsAny<AsyncCallback>(), It.IsAny<object>()))
+        .Returns((AsyncCallback callback, object state) => {
+          TaskCompletionSource<WebResponse> tcs = new TaskCompletionSource<WebResponse>(state);
+          Task.FromResult(webResponse.Object)
+            .ContinueWith(completedTask => {
+              if (tcs.TrySetResult(webResponse.Object))
+                callback(tcs.Task);
+              return webResponse.Object;
+            }, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default);
+          return tcs.Task;
+        });
+
+      webRequest
+        .Setup(x => x.EndGetResponse(It.IsAny<IAsyncResult>()))
+        .Returns((IAsyncResult asyncResult) => webResponse.Object);
+
+      return webRequest.Object;
+    }
+  }
+
+}

--- a/MetaBrainz.MusicBrainz.sln
+++ b/MetaBrainz.MusicBrainz.sln
@@ -1,12 +1,14 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.13
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetaBrainz.MusicBrainz", "MetaBrainz.MusicBrainz\MetaBrainz.MusicBrainz.csproj", "{662BD624-2529-405F-9AC5-925C4401FB45}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetaBrainz.MusicBrainz", "MetaBrainz.MusicBrainz\MetaBrainz.MusicBrainz.csproj", "{662BD624-2529-405F-9AC5-925C4401FB45}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Files", "{F997B31A-CF25-4C63-BEB5-172F7E13D9B3}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+		appveyor.yml = appveyor.yml
 		build\Common.props = build\Common.props
 		build\Common.targets = build\Common.targets
 		Directory.Build.props = Directory.Build.props
@@ -16,9 +18,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Support Files", "Support Fi
 		build\TargetFrameworkVersionDefineConstants.targets = build\TargetFrameworkVersionDefineConstants.targets
 		UserGuide.md = UserGuide.md
 		build\Versioning.targets = build\Versioning.targets
-		.editorconfig = .editorconfig
-		appveyor.yml = appveyor.yml
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetaBrainz.MusicBrainz.Tests", "MetaBrainz.MusicBrainz.Tests\MetaBrainz.MusicBrainz.Tests.csproj", "{5E31D16D-1F9E-49E9-B627-C6F2147341B5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -30,10 +32,15 @@ Global
 		{662BD624-2529-405F-9AC5-925C4401FB45}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{662BD624-2529-405F-9AC5-925C4401FB45}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{662BD624-2529-405F-9AC5-925C4401FB45}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5E31D16D-1F9E-49E9-B627-C6F2147341B5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5E31D16D-1F9E-49E9-B627-C6F2147341B5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5E31D16D-1F9E-49E9-B627-C6F2147341B5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5E31D16D-1F9E-49E9-B627-C6F2147341B5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {67EFA56C-E953-4D42-AD3B-BE071D4A5781}
 	EndGlobalSection
 EndGlobal

--- a/MetaBrainz.MusicBrainz/Query.cs
+++ b/MetaBrainz.MusicBrainz/Query.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Net;
 
 using JetBrains.Annotations;
 
@@ -103,6 +104,14 @@ namespace MetaBrainz.MusicBrainz {
         var an = typeof(Query).Assembly.GetName();
         this.FullUserAgent = $"{this.UserAgent} {an.Name}/{an.Version} ({Query.UserAgentUrl})";
       }
+    }
+
+    /// <summary>
+    /// Creates a new instance of the <see cref="Query"/> class with the specified <see cref="WebClient"/> instance, useful for testing.
+    /// </summary>
+    /// <param name="webClient">The instance of the WebClient to use for requests - provide a mocked instance to test.</param>
+    public Query(WebClient webClient) : this("xUnit Tests") {
+      this.TheClient = webClient;
     }
 
     #endregion


### PR DESCRIPTION
I've created a strategy for mocking the responses to the WebClient class and added a sample unit test on the browse releases. Should be relatively easy to build out more tests from here. Let me know what you think.