### PR TITLE
Drop `[JsonConverter]` from `PartialDate`

### DIFF
--- a/MetaBrainz.MusicBrainz/PartialDate.cs
+++ b/MetaBrainz.MusicBrainz/PartialDate.cs
@@ -1,17 +1,13 @@
 ﻿using System;
 using System.Globalization;
 using System.Text;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 
 using JetBrains.Annotations;
 
-using MetaBrainz.MusicBrainz.Json.Readers;
-
 namespace MetaBrainz.MusicBrainz;
 
 /// <summary>A partial date. Can contain any or all of year, month and day.</summary>
-[JsonConverter(typeof(PartialDateReader))]
 [PublicAPI]
 public sealed class PartialDate : IComparable<PartialDate>, IEquatable<PartialDate> {
 


### PR DESCRIPTION
Otherwise, user (de)serialization of `PartialDate` objects will use our reader, effectively preventing serialization.

No other changes should be needed; `PartialDate` is a not a top-level type in the MB API, so its reader is used directly by the readers for containing types.

Fixes #28.