### PR TITLE
API Updates

### DIFF
--- a/MetaBrainz.MusicBrainz/Interfaces/Entities/IRecording.cs
+++ b/MetaBrainz.MusicBrainz/Interfaces/Entities/IRecording.cs
@@ -12,6 +12,9 @@ public interface IRecording : IAliasedEntity, IAnnotatedEntity, IRatableEntity, 
   /// <summary>The artist credit for the recording.</summary>
   IReadOnlyList<INameCredit>? ArtistCredit { get; }
 
+  /// <summary>The earliest date of release for this recording.</summary>
+  PartialDate? FirstReleaseDate { get; }
+
   /// <summary>The ISRC (International Standard Recording Code) values associated with this release.</summary>
   IReadOnlyList<string>? Isrcs { get; }
 

--- a/MetaBrainz.MusicBrainz/Json/Readers/RecordingReader.cs
+++ b/MetaBrainz.MusicBrainz/Json/Readers/RecordingReader.cs
@@ -18,6 +18,7 @@ internal sealed class RecordingReader : ObjectReader<Recording> {
     string? annotation = null;
     IReadOnlyList<INameCredit>? artistCredit = null;
     string? disambiguation = null;
+    PartialDate? firstReleaseDate = null;
     IReadOnlyList<IGenre>? genres = null;
     Guid? id = null;
     IReadOnlyList<string>? isrcs = null;
@@ -48,6 +49,9 @@ internal sealed class RecordingReader : ObjectReader<Recording> {
             break;
           case "disambiguation":
             disambiguation = reader.GetString();
+            break;
+          case "first-release-date":
+            firstReleaseDate = reader.GetOptionalObject(PartialDateReader.Instance, options);
             break;
           case "genres":
             genres = reader.ReadList(GenreReader.Instance, options);
@@ -107,6 +111,7 @@ internal sealed class RecordingReader : ObjectReader<Recording> {
       Annotation = annotation,
       ArtistCredit = artistCredit,
       Disambiguation = disambiguation,
+      FirstReleaseDate = firstReleaseDate,
       Genres = genres,
       Isrcs = isrcs,
       Length = length,

--- a/MetaBrainz.MusicBrainz/Json/Readers/ReleaseReader.cs
+++ b/MetaBrainz.MusicBrainz/Json/Readers/ReleaseReader.cs
@@ -145,7 +145,7 @@ internal sealed class ReleaseReader : ObjectReader<Release> {
             releaseEvents = reader.ReadList(ReleaseEventReader.Instance, options);
             break;
           case "release-group":
-            releaseGroup = reader.GetObject(ReleaseGroupReader.Instance, options);
+            releaseGroup = reader.GetOptionalObject(ReleaseGroupReader.Instance, options);
             break;
           case "status":
             status = reader.GetString();

--- a/MetaBrainz.MusicBrainz/Objects/Entities/Recording.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Entities/Recording.cs
@@ -18,6 +18,8 @@ internal sealed class Recording : Entity, IRecording {
 
   public string? Disambiguation { get; set; }
 
+  public PartialDate? FirstReleaseDate { get; set; }
+
   public IReadOnlyList<IGenre>? Genres { get; set; }
 
   public IReadOnlyList<string>? Isrcs { get; set; }


### PR DESCRIPTION
This makes two changes related to the MB API:
- a release's `release-group` field can now be specified as `null` (because that's what MB currently seems to send)
- `IRecording` now has a `FirstReleaseDate` property
