### PR TITLE
Avoid more Rider inspections

### DIFF
--- a/MetaBrainz.MusicBrainz/OAuth2.cs
+++ b/MetaBrainz.MusicBrainz/OAuth2.cs
@@ -222,7 +222,7 @@ public class OAuth2 {
 
   private async Task<AuthorizationToken> ProcessResponseAsync(HttpWebResponse response) {
     Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({response.ContentType}): {response.ContentLength} bytes");
-#if NET || NETCOREAPP2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
     var stream = response.GetResponseStream();
     await using var _ = stream.ConfigureAwait(false);
 #else
@@ -298,7 +298,7 @@ public class OAuth2 {
   }
 
   private async Task<HttpWebResponse> SendRequestAsync(HttpWebRequest req, string body) {
-#if NET || NETCOREAPP2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
     var rs = req.GetRequestStream();
     await using var _ = rs.ConfigureAwait(false);
 #else

--- a/MetaBrainz.MusicBrainz/Query.Internals.cs
+++ b/MetaBrainz.MusicBrainz/Query.Internals.cs
@@ -37,6 +37,11 @@ public sealed partial class Query : IDisposable {
     }
     try {
       using var stream = response.GetResponseStream();
+#if !NET
+      if (stream == null) {
+        return;
+      }
+#endif
       if (response.ContentType.StartsWith("application/xml")) {
         Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({response.ContentType}): <{response.ContentLength} byte(s)>");
         StringBuilder? sb = null;
@@ -92,11 +97,13 @@ public sealed partial class Query : IDisposable {
       return;
     }
     try {
-#if NET || NETCOREAPP2_1_OR_GREATER
+#if NET || NETSTANDARD2_1_OR_GREATER
       var stream = response.GetResponseStream();
       await using var _ = stream.ConfigureAwait(false);
 #else
       using var stream = response.GetResponseStream();
+#endif
+#if !NET
       if (stream is null) {
         return;
       }


### PR DESCRIPTION
The multi-targeting does make it trickier to avoid inspections for all targets.

This also corrects the conditional compilation, using `NETSTANDARD2_1_OR_GREATER` instead of `NETCOREAPP_1_OR_GREATER`.