### PR TITLE
Let IPagedQueryResults implement IAsyncEnumerable

### DIFF
--- a/MetaBrainz.MusicBrainz/Interfaces/IPagedQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Interfaces/IPagedQueryResults.cs
@@ -12,7 +12,7 @@ namespace MetaBrainz.MusicBrainz.Interfaces;
 /// <typeparam name="TInterface">The specific type of query result.</typeparam>
 /// <typeparam name="TItem">The type of item being returned.</typeparam>
 [PublicAPI]
-public interface IPagedQueryResults<TInterface, out TItem> : IJsonBasedObject
+public interface IPagedQueryResults<TInterface, out TItem> : IJsonBasedObject, IAsyncEnumerable<TItem>
 where TInterface : IPagedQueryResults<TInterface, TItem> {
 
   /// <summary>

--- a/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net.Http;
+using System.Threading;
 using System.Threading.Tasks;
 
 using MetaBrainz.MusicBrainz.Interfaces;
@@ -94,5 +95,19 @@ where TResultObject : class {
   }
 
   private readonly string? _value;
+
+  public async IAsyncEnumerator<TItem> GetAsyncEnumerator(CancellationToken cancellationToken = new ()) {
+    foreach (var item in this.Results) {
+      yield return item;
+    }
+    var current = await this.NextAsync();
+    while (current.Results.Count > 0 && !cancellationToken.IsCancellationRequested) {
+      foreach (var item in current.Results) {
+        yield return item;
+      }
+      current = await current.NextAsync();
+    }
+  }
+  
 
 }


### PR DESCRIPTION
This change allows for convenient async enumeration of results with transparent paging:
```csharp
await foreach (var item in results) {
  // do something with item
}
```