### PR TITLE
Async tweaks

### DIFF
--- a/MetaBrainz.MusicBrainz/Interfaces/IPagedQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Interfaces/IPagedQueryResults.cs
@@ -58,7 +58,7 @@ where TResults : IPagedQueryResults<TResults, TItem> {
   /// <returns>This result set (with updated values).</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  Task<TResults> NextAsync(CancellationToken cancellationToken = new());
+  Task<TResults> NextAsync(CancellationToken cancellationToken = default);
 
   /// <summary>
   /// The offset to use for the next request (via <see cref="Next()"/> and/or <see cref="Previous()"/>), or <see langword="null"/>
@@ -89,7 +89,7 @@ where TResults : IPagedQueryResults<TResults, TItem> {
   /// <returns>This result set (with updated values).</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  Task<TResults> PreviousAsync(CancellationToken cancellationToken = new());
+  Task<TResults> PreviousAsync(CancellationToken cancellationToken = default);
 
   /// <summary>The current results.</summary>
   IReadOnlyList<TItem> Results { get; }

--- a/MetaBrainz.MusicBrainz/OAuth2.cs
+++ b/MetaBrainz.MusicBrainz/OAuth2.cs
@@ -256,8 +256,6 @@ public sealed class OAuth2 : IDisposable {
 
   private Func<HttpClient>? _clientCreation;
 
-  private readonly SemaphoreSlim _clientLock = new(1);
-
   private readonly bool _clientOwned;
 
   private bool _disposed;
@@ -285,14 +283,7 @@ public sealed class OAuth2 : IDisposable {
     if (!this._clientOwned) {
       throw new InvalidOperationException("An explicitly provided client instance is in use.");
     }
-    this._clientLock.Wait();
-    try {
-      this._client?.Dispose();
-      this._client = null;
-    }
-    finally {
-      this._clientLock.Release();
-    }
+    Interlocked.Exchange(ref this._client, null)?.Dispose();
   }
 
   /// <summary>Sets up code to run to configure a newly-created HTTP client.</summary>
@@ -328,7 +319,6 @@ public sealed class OAuth2 : IDisposable {
         this.Close();
       }
       this._client = null;
-      this._clientLock.Dispose();
     }
     finally {
       this._disposed = true;
@@ -348,52 +338,48 @@ public sealed class OAuth2 : IDisposable {
   private async Task<HttpResponseMessage> PerformRequestAsync(Uri uri, HttpMethod method, HttpContent? body,
                                                               CancellationToken cancellationToken) {
     Debug.Print($"[{DateTime.UtcNow}] WEB SERVICE REQUEST: {method.Method} {uri}");
-    await this._clientLock.WaitAsync(cancellationToken);
-    try {
-      var client = this.Client;
-      using var request = new HttpRequestMessage(method, uri) {
-        Content = body,
-        Headers = {
-          Accept = {
-            OAuth2.AcceptHeader,
-          },
-        }
-      };
-      // Use whatever user agent the client has set, plus our own.
-      foreach (var userAgent in client.DefaultRequestHeaders.UserAgent) {
-        request.Headers.UserAgent.Add(userAgent);
+    var client = this.Client;
+    using var request = new HttpRequestMessage(method, uri) {
+      Content = body,
+      Headers = {
+        Accept = {
+          OAuth2.AcceptHeader,
+        },
       }
-      request.Headers.UserAgent.Add(OAuth2.LibraryProductInfo);
-      request.Headers.UserAgent.Add(OAuth2.LibraryComment);
-      Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {Utils.FormatMultiLine(request.Headers.ToString())}");
-      if (body is not null) {
-        // FIXME: Should this include the actual body text too?
-        Debug.Print($"[{DateTime.UtcNow}] => BODY ({body.Headers.ContentType}): {body.Headers.ContentLength ?? 0} bytes");
-      }
-      var response = await client.SendAsync(request, cancellationToken);
-      Debug.Print($"[{DateTime.UtcNow}] WEB SERVICE RESPONSE: {(int) response.StatusCode}/{response.StatusCode} " +
-                  $"'{response.ReasonPhrase}' (v{response.Version})");
-      Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {Utils.FormatMultiLine(response.Headers.ToString())}");
-      Debug.Print($"[{DateTime.UtcNow}] => CONTENT ({response.Content.Headers.ContentType}): " +
-                  $"{response.Content.Headers.ContentLength ?? 0} bytes");
-      return response;
+    };
+    // Use whatever user agent the client has set, plus our own.
+    foreach (var userAgent in client.DefaultRequestHeaders.UserAgent) {
+      request.Headers.UserAgent.Add(userAgent);
     }
-    finally {
-      this._clientLock.Release();
+    request.Headers.UserAgent.Add(OAuth2.LibraryProductInfo);
+    request.Headers.UserAgent.Add(OAuth2.LibraryComment);
+    Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {Utils.FormatMultiLine(request.Headers.ToString())}");
+    if (body is not null) {
+      // FIXME: Should this include the actual body text too?
+      Debug.Print($"[{DateTime.UtcNow}] => BODY ({body.Headers.ContentType}): {body.Headers.ContentLength ?? 0} bytes");
     }
+    var response = await client.SendAsync(request, cancellationToken).ConfigureAwait(false);
+    Debug.Print($"[{DateTime.UtcNow}] WEB SERVICE RESPONSE: {(int) response.StatusCode}/{response.StatusCode} " +
+                $"'{response.ReasonPhrase}' (v{response.Version})");
+    Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {Utils.FormatMultiLine(response.Headers.ToString())}");
+    Debug.Print($"[{DateTime.UtcNow}] => CONTENT ({response.Content.Headers.ContentType}): " +
+                $"{response.Content.Headers.ContentLength ?? 0} bytes");
+    return response;
   }
 
-  private async Task<AuthorizationToken> PostAsync(HttpContent body, CancellationToken cancellationToken) {
+  private async Task<AuthorizationToken> PostAsync(HttpContent content, CancellationToken cancellationToken) {
     var uri = new UriBuilder(this.UrlScheme, this.Server, this.Port, OAuth2.TokenEndPoint).Uri;
-    var response = await this.PerformRequestAsync(uri, HttpMethod.Post, body, cancellationToken);
+    var response = await this.PerformRequestAsync(uri, HttpMethod.Post, content, cancellationToken).ConfigureAwait(false);
     if (!response.IsSuccessStatusCode) {
-      throw await Utils.CreateQueryExceptionForAsync(response, cancellationToken);
+      throw await Utils.CreateQueryExceptionForAsync(response, cancellationToken).ConfigureAwait(false);
     }
-    return await Utils.GetJsonContentAsync<AuthorizationToken>(response, OAuth2.JsonReaderOptions, cancellationToken);
+    var jsonTask = Utils.GetJsonContentAsync<AuthorizationToken>(response, OAuth2.JsonReaderOptions, cancellationToken);
+    return await jsonTask.ConfigureAwait(false);
   }
 
   private async Task<IAuthorizationToken> PostAsync(string type, string body, CancellationToken cancellationToken) {
-    var token = await this.PostAsync(new StringContent(body, Encoding.UTF8, OAuth2.TokenRequestBodyType), cancellationToken);
+    var content = new StringContent(body, Encoding.UTF8, OAuth2.TokenRequestBodyType);
+    var token = await this.PostAsync(content, cancellationToken).ConfigureAwait(false);
     if (token.TokenType != type) {
       throw new InvalidOperationException($"Token request returned a token of the wrong type ('{token.TokenType}' != '{type}').");
     }
@@ -408,7 +394,7 @@ public sealed class OAuth2 : IDisposable {
     body.Append("&token_type=").Append(Uri.EscapeDataString(type));
     body.Append("&grant_type=refresh_token");
     body.Append("&refresh_token=").Append(Uri.EscapeDataString(codeOrToken));
-    return await this.PostAsync(type, body.ToString(), cancellationToken);
+    return await this.PostAsync(type, body.ToString(), cancellationToken).ConfigureAwait(false);
   }
 
   private async Task<IAuthorizationToken> RequestTokenAsync(string type, string codeOrToken, string clientSecret, Uri redirectUri,
@@ -420,7 +406,7 @@ public sealed class OAuth2 : IDisposable {
     body.Append("&grant_type=authorization_code");
     body.Append("&code=").Append(Uri.EscapeDataString(codeOrToken));
     body.Append("&redirect_uri=").Append(Uri.EscapeDataString(redirectUri.ToString()));
-    return await this.PostAsync(type, body.ToString(), cancellationToken);
+    return await this.PostAsync(type, body.ToString(), cancellationToken).ConfigureAwait(false);
   }
 
   private static IEnumerable<string> ScopeStrings(AuthorizationScope scope) {

--- a/MetaBrainz.MusicBrainz/OAuth2.cs
+++ b/MetaBrainz.MusicBrainz/OAuth2.cs
@@ -219,7 +219,7 @@ public sealed class OAuth2 : IDisposable {
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The obtained bearer token.</returns>
   public Task<IAuthorizationToken> GetBearerTokenAsync(string code, string clientSecret, Uri redirectUri,
-                                                       CancellationToken cancellationToken = new())
+                                                       CancellationToken cancellationToken = default)
     => this.RequestTokenAsync("bearer", code, clientSecret, redirectUri, cancellationToken);
 
   /// <summary>Refreshes a bearer token.</summary>
@@ -235,7 +235,7 @@ public sealed class OAuth2 : IDisposable {
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The obtained bearer token.</returns>
   public Task<IAuthorizationToken> RefreshBearerTokenAsync(string refreshToken, string clientSecret,
-                                                           CancellationToken cancellationToken = new())
+                                                           CancellationToken cancellationToken = default)
     => this.RefreshTokenAsync("bearer", refreshToken, clientSecret, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseResults.cs
@@ -22,7 +22,8 @@ where TResult : IEntity {
 
   protected sealed override async Task<IBrowseResults<TResult>> DeserializeAsync(HttpResponseMessage response,
                                                                                  CancellationToken cancellationToken) {
-    this.CurrentResult = await Utils.GetJsonContentAsync<BrowseResult>(response, Query.JsonReaderOptions, cancellationToken);
+    var task = Utils.GetJsonContentAsync<BrowseResult>(response, Query.JsonReaderOptions, cancellationToken);
+    this.CurrentResult = await task.ConfigureAwait(false);
     return this;
   }
 

--- a/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
@@ -33,7 +33,7 @@ where TResultObject : class {
 
   public TResults Next() => Utils.ResultOf(this.NextAsync());
 
-  public async Task<TResults> NextAsync(CancellationToken cancellationToken = new()) {
+  public async Task<TResults> NextAsync(CancellationToken cancellationToken = default) {
     this.UpdateOffset(this.Results.Count);
     return await this.PerformRequestAsync(cancellationToken).ConfigureAwait(false);
   }
@@ -44,7 +44,7 @@ where TResultObject : class {
 
   public TResults Previous() => Utils.ResultOf(this.PreviousAsync());
 
-  public async Task<TResults> PreviousAsync(CancellationToken cancellationToken = new()) {
+  public async Task<TResults> PreviousAsync(CancellationToken cancellationToken = default) {
     this.UpdateOffset();
     return await this.PerformRequestAsync(cancellationToken).ConfigureAwait(false);
   }

--- a/MetaBrainz.MusicBrainz/Objects/Searches/SearchResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Searches/SearchResults.cs
@@ -75,7 +75,8 @@ where TInterface : ISearchResult {
 
   protected sealed override async Task<ISearchResults<TInterface>> DeserializeAsync(HttpResponseMessage response,
                                                                                     CancellationToken cancellationToken) {
-    this.CurrentResult = await Utils.GetJsonContentAsync<SearchResults>(response, Query.JsonReaderOptions, cancellationToken);
+    var task = Utils.GetJsonContentAsync<SearchResults>(response, Query.JsonReaderOptions, cancellationToken);
+    this.CurrentResult = await task.ConfigureAwait(false);
     if (this.Offset != this.CurrentResult.Offset) {
       Debug.Print($"Unexpected offset in search results: {this.Offset} != {this.CurrentResult.Offset}.");
     }

--- a/MetaBrainz.MusicBrainz/Objects/StreamingQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/StreamingQueryResults.cs
@@ -21,7 +21,7 @@ where TResultObject : class {
   public async IAsyncEnumerator<TItem> GetAsyncEnumerator(CancellationToken cancellationToken = new()) {
     IPagedQueryResults<TResult, TItem> currentPage = this._pagedResults;
     if (!currentPage.IsActive) {
-      currentPage = await currentPage.NextAsync(cancellationToken);
+      currentPage = await currentPage.NextAsync(cancellationToken).ConfigureAwait(false);
       if (cancellationToken.IsCancellationRequested) {
         yield break;
       }
@@ -36,7 +36,7 @@ where TResultObject : class {
       if (currentPage.Offset + currentPage.Results.Count >= currentPage.TotalResults || cancellationToken.IsCancellationRequested) {
         break;
       }
-      currentPage = await currentPage.NextAsync(cancellationToken);
+      currentPage = await currentPage.NextAsync(cancellationToken).ConfigureAwait(false);
     }
   }
 

--- a/MetaBrainz.MusicBrainz/Objects/StreamingQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/StreamingQueryResults.cs
@@ -18,7 +18,7 @@ where TResultObject : class {
 
   #region IAsyncEnumerable
 
-  public async IAsyncEnumerator<TItem> GetAsyncEnumerator(CancellationToken cancellationToken = new()) {
+  public async IAsyncEnumerator<TItem> GetAsyncEnumerator(CancellationToken cancellationToken = default) {
     IPagedQueryResults<TResult, TItem> currentPage = this._pagedResults;
     if (!currentPage.IsActive) {
       currentPage = await currentPage.NextAsync(cancellationToken).ConfigureAwait(false);

--- a/MetaBrainz.MusicBrainz/Objects/Submissions/Submission.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Submissions/Submission.cs
@@ -28,7 +28,7 @@ public abstract class Submission : ISubmission {
   /// <returns>A message describing the result (usually "OK").</returns>
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="System.Net.WebException">When the MusicBrainz web service could not be contacted.</exception>
-  public async Task<string> SubmitAsync(CancellationToken cancellationToken = new())
+  public async Task<string> SubmitAsync(CancellationToken cancellationToken = default)
     => await this._query.PerformSubmissionAsync(this, cancellationToken).ConfigureAwait(false);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Browse.Areas.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Areas.cs
@@ -68,7 +68,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArea>> BrowseAreasAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                      Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                      Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the areas in the given collection.</summary>
@@ -93,7 +93,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArea>> BrowseCollectionAreasAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
-                                                                CancellationToken cancellationToken = new())
+                                                                CancellationToken cancellationToken = default)
     => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Artists.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Artists.cs
@@ -238,7 +238,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseAreaArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
-                                                              CancellationToken cancellationToken = new())
+                                                              CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given area.</summary>
@@ -320,7 +320,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IArea area, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
@@ -333,7 +333,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given recording.</summary>
@@ -346,7 +346,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IRecording recording, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", recording.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release.</summary>
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IRelease release, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release group.</summary>
@@ -372,7 +372,8 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new()) {
+                                                          Include inc = Include.None,
+                                                          CancellationToken cancellationToken = default) {
     var browse = new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -387,7 +388,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IWork work, int? limit = null, int? offset = null,
-                                                          Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "work", work.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
@@ -413,7 +414,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseCollectionArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                     Include inc = Include.None,
-                                                                    CancellationToken cancellationToken = new())
+                                                                    CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given recording.</summary>
@@ -439,7 +440,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseRecordingArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                    Include inc = Include.None,
-                                                                   CancellationToken cancellationToken = new())
+                                                                   CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release.</summary>
@@ -464,7 +465,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseReleaseArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                  Include inc = Include.None,
-                                                                 CancellationToken cancellationToken = new())
+                                                                 CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release group.</summary>
@@ -490,7 +491,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseReleaseGroupArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None,
-                                                                      CancellationToken cancellationToken = new())
+                                                                      CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given work.</summary>
@@ -515,7 +516,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseWorkArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
-                                                              CancellationToken cancellationToken = new())
+                                                              CancellationToken cancellationToken = default)
     => new BrowseArtists(this, Query.BuildExtraText(inc, "work", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Collections.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Collections.cs
@@ -377,7 +377,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseAreaCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                      CancellationToken cancellationToken = new())
+                                                                      CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given artist.</summary>
@@ -399,7 +399,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseArtistCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                        CancellationToken cancellationToken = new())
+                                                                        CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("artist", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given area.</summary>
@@ -521,7 +521,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IArea area, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given artist.</summary>
@@ -533,7 +533,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IArtist artist, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("artist", artist.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given event.</summary>
@@ -545,7 +545,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IEvent @event, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("event", @event.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given instrument.</summary>
@@ -557,7 +557,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IInstrument instrument, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("instrument", instrument.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given label.</summary>
@@ -569,7 +569,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(ILabel label, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("label", label.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given place.</summary>
@@ -581,7 +581,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IPlace place, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("place", place.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given recording.</summary>
@@ -593,7 +593,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IRecording recording, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("recording", recording.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release.</summary>
@@ -605,7 +605,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IRelease release, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("release", release.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release group.</summary>
@@ -617,7 +617,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new()) {
+                                                                  CancellationToken cancellationToken = default) {
     var browse = new BrowseCollections(this, Query.BuildExtraText("release-group", releaseGroup.Id), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -631,7 +631,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(ISeries series, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("series", series.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given work.</summary>
@@ -643,7 +643,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IWork work, int? limit = null, int? offset = null,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("work", work.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections of the given editor.</summary>
@@ -665,7 +665,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseEditorCollectionsAsync(string editor, int? limit = null, int? offset = null,
-                                                                        CancellationToken cancellationToken = new())
+                                                                        CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("editor", editor), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given event.</summary>
@@ -687,7 +687,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseEventCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("event", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given instrument.</summary>
@@ -709,7 +709,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseInstrumentCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                            CancellationToken cancellationToken = new())
+                                                                            CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("instrument", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given label.</summary>
@@ -731,7 +731,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseLabelCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("label", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given place.</summary>
@@ -753,7 +753,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowsePlaceCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("place", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given recording.</summary>
@@ -775,7 +775,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseRecordingCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                           CancellationToken cancellationToken = new())
+                                                                           CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("recording", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release.</summary>
@@ -797,7 +797,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseReleaseCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                         CancellationToken cancellationToken = new())
+                                                                         CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("release", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release group.</summary>
@@ -819,7 +819,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseReleaseGroupCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                              CancellationToken cancellationToken = new())
+                                                                              CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("release-group", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given series.</summary>
@@ -841,7 +841,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseSeriesCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                        CancellationToken cancellationToken = new())
+                                                                        CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("series", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given work.</summary>
@@ -863,7 +863,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseWorkCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                                      CancellationToken cancellationToken = new())
+                                                                      CancellationToken cancellationToken = default)
     => new BrowseCollections(this, Query.BuildExtraText("work", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Events.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Events.cs
@@ -169,7 +169,8 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseAreaEventsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                            Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                            Include inc = Include.None,
+                                                            CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given artist.</summary>
@@ -194,7 +195,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseArtistEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
-                                                              CancellationToken cancellationToken = new())
+                                                              CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events in the given collection.</summary>
@@ -219,7 +220,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseCollectionEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given area.</summary>
@@ -277,7 +278,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IArea area, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given artist.</summary>
@@ -290,7 +291,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IArtist artist, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events in the given collection.</summary>
@@ -303,7 +304,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given place.</summary>
@@ -316,7 +317,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IPlace place, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "place", place.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given place.</summary>
@@ -341,7 +342,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IEvent>> BrowsePlaceEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                              Include inc = Include.None,
-                                                             CancellationToken cancellationToken = new())
+                                                             CancellationToken cancellationToken = default)
     => new BrowseEvents(this, Query.BuildExtraText(inc, "place", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Instruments.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Instruments.cs
@@ -69,7 +69,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IInstrument>> BrowseInstrumentsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
-                                                                  CancellationToken cancellationToken = new()) {
+                                                                  CancellationToken cancellationToken = default) {
     var browse = new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -97,7 +97,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IInstrument>> BrowseCollectionInstrumentsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                             Include inc = Include.None,
-                                                                            CancellationToken cancellationToken = new())
+                                                                            CancellationToken cancellationToken = default)
     => new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Labels.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Labels.cs
@@ -135,7 +135,8 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseAreaLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                            Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                            Include inc = Include.None,
+                                                            CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels in the given collection.</summary>
@@ -160,7 +161,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseCollectionLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given area.</summary>
@@ -207,7 +208,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(IArea area, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels in the given collection.</summary>
@@ -220,7 +221,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given release.</summary>
@@ -233,7 +234,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(IRelease release, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given release.</summary>
@@ -258,7 +259,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseReleaseLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                Include inc = Include.None,
-                                                               CancellationToken cancellationToken = new())
+                                                               CancellationToken cancellationToken = default)
     => new BrowseLabels(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Places.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Places.cs
@@ -101,7 +101,8 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IPlace>> BrowseAreaPlacesAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                            Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                            Include inc = Include.None,
+                                                            CancellationToken cancellationToken = default)
     => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places in the given collection.</summary>
@@ -126,7 +127,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IPlace>> BrowseCollectionPlacesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
-                                                                  CancellationToken cancellationToken = new())
+                                                                  CancellationToken cancellationToken = default)
     => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places associated with the given area.</summary>
@@ -162,7 +163,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IPlace>> BrowsePlacesAsync(IArea area, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places in the given collection.</summary>
@@ -175,7 +176,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IPlace>> BrowsePlacesAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                        Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                        Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Recordings.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Recordings.cs
@@ -137,7 +137,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseArtistRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None,
-                                                                      CancellationToken cancellationToken = new())
+                                                                      CancellationToken cancellationToken = default)
     => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings in the given collection.</summary>
@@ -163,7 +163,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseCollectionRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                           Include inc = Include.None,
-                                                                          CancellationToken cancellationToken = new())
+                                                                          CancellationToken cancellationToken = default)
     => new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings associated with the given artist.</summary>
@@ -213,7 +213,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
-                                                                CancellationToken cancellationToken = new())
+                                                                CancellationToken cancellationToken = default)
     => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings in the given collection.</summary>
@@ -227,7 +227,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
-                                                                CancellationToken cancellationToken = new()) {
+                                                                CancellationToken cancellationToken = default) {
     var browse = new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -243,7 +243,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(IRelease release, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
-                                                                CancellationToken cancellationToken = new())
+                                                                CancellationToken cancellationToken = default)
     => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings associated with the given release.</summary>
@@ -269,7 +269,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IRecording>> BrowseReleaseRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        Include inc = Include.None,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.ReleaseGroups.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.ReleaseGroups.cs
@@ -146,7 +146,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IReleaseGroup>> BrowseArtistReleaseGroupsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                             Include inc = Include.None, ReleaseType? type = null,
-                                                                            CancellationToken cancellationToken = new())
+                                                                            CancellationToken cancellationToken = default)
     => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", mbid, type), limit, offset).NextAsync(cancellationToken);
 
   /// <inheritdoc cref="BrowseCollectionReleaseGroupsAsync"/>
@@ -167,7 +167,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseCollectionReleaseGroupsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                                 Include inc = Include.None,
                                                                                 ReleaseType? type = null,
-                                                                                CancellationToken cancellationToken = new()) {
+                                                                                CancellationToken cancellationToken = default) {
     var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", mbid, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -193,7 +193,7 @@ public sealed partial class Query {
   /// </remarks>
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseReleaseGroupsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                              Include inc = Include.None, ReleaseType? type = null,
-                                                                             CancellationToken cancellationToken = new())
+                                                                             CancellationToken cancellationToken = default)
     => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", mbid, type), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the release groups associated with the given artist.</summary>
@@ -250,7 +250,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
-                                                                      CancellationToken cancellationToken = new()) {
+                                                                      CancellationToken cancellationToken = default) {
     var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", artist.Id, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -267,7 +267,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
-                                                                      CancellationToken cancellationToken = new()) {
+                                                                      CancellationToken cancellationToken = default) {
     var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", collection.Id, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -287,7 +287,7 @@ public sealed partial class Query {
   /// </remarks>
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(IRelease release, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
-                                                                      CancellationToken cancellationToken = new()) {
+                                                                      CancellationToken cancellationToken = default) {
     var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", release.Id, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Releases.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Releases.cs
@@ -366,7 +366,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseAreaReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None, ReleaseType? type = null,
                                                                 ReleaseStatus? status = null,
-                                                                CancellationToken cancellationToken = new())
+                                                                CancellationToken cancellationToken = default)
     => new BrowseReleases(this, Query.BuildExtraText(inc, "area", mbid, type, status), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given artist.</summary>
@@ -397,7 +397,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseArtistReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None, ReleaseType? type = null,
                                                                   ReleaseStatus? status = null,
-                                                                  CancellationToken cancellationToken = new()) {
+                                                                  CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "artist", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -431,7 +431,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseCollectionReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       ReleaseStatus? status = null,
-                                                                      CancellationToken cancellationToken = new()) {
+                                                                      CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "collection", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -464,7 +464,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseLabelReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null,
-                                                                 CancellationToken cancellationToken = new())
+                                                                 CancellationToken cancellationToken = default)
     => new BrowseReleases(this, Query.BuildExtraText(inc, "label", mbid, type, status), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given recording.</summary>
@@ -496,7 +496,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseRecordingReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                      Include inc = Include.None, ReleaseType? type = null,
                                                                      ReleaseStatus? status = null,
-                                                                     CancellationToken cancellationToken = new()) {
+                                                                     CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "recording", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -530,7 +530,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleaseGroupReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                         Include inc = Include.None, ReleaseType? type = null,
                                                                         ReleaseStatus? status = null,
-                                                                        CancellationToken cancellationToken = new()) {
+                                                                        CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -648,7 +648,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(IArea area, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "area", area.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -667,7 +667,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(IArtist artist, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "artist", artist.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -686,7 +686,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(ICollection collection, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "collection", collection.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -705,7 +705,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(ILabel label, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "label", label.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -724,7 +724,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(IRecording recording, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "recording", recording.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -743,7 +743,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -762,7 +762,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseReleasesAsync(ITrack track, int? limit = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
-                                                            CancellationToken cancellationToken = new()) {
+                                                            CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track", track.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -817,7 +817,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseTrackArtistReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null,
-                                                                       CancellationToken cancellationToken = new()) {
+                                                                       CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -838,7 +838,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseTrackArtistReleasesAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null,
-                                                                       CancellationToken cancellationToken = new()) {
+                                                                       CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", artist.Id, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
@@ -871,7 +871,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRelease>> BrowseTrackReleasesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null,
-                                                                 CancellationToken cancellationToken = new()) {
+                                                                 CancellationToken cancellationToken = default) {
     var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track", mbid, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Series.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Series.cs
@@ -69,7 +69,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ISeries>> BrowseCollectionSeriesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                    Include inc = Include.None,
-                                                                   CancellationToken cancellationToken = new())
+                                                                   CancellationToken cancellationToken = default)
     => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the series in the given collection.</summary>
@@ -94,7 +94,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<ISeries>> BrowseSeriesAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                         Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Works.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Works.cs
@@ -101,7 +101,8 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IWork>> BrowseArtistWorksAsync(Guid mbid, int? limit = null, int? offset = null,
-                                                            Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                            Include inc = Include.None,
+                                                            CancellationToken cancellationToken = default)
     => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works in the given collection.</summary>
@@ -126,7 +127,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IWork>> BrowseCollectionWorksAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
-                                                                CancellationToken cancellationToken = new())
+                                                                CancellationToken cancellationToken = default)
     => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works associated with the given artist.</summary>
@@ -162,7 +163,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IWork>> BrowseWorksAsync(IArtist artist, int? limit = null, int? offset = null,
-                                                      Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                      Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works in the given collection.</summary>
@@ -175,7 +176,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public Task<IBrowseResults<IWork>> BrowseWorksAsync(ICollection collection, int? limit = null, int? offset = null,
-                                                      Include inc = Include.None, CancellationToken cancellationToken = new())
+                                                      Include inc = Include.None, CancellationToken cancellationToken = default)
     => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Collections.Areas.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Areas.cs
@@ -132,7 +132,8 @@ public sealed partial class Query {
   /// <exception cref="ArgumentException">When <paramref name="client"/> is blank.</exception>
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
-  public Task<string> AddToCollectionAsync(string client, Guid collection, IArea area, CancellationToken cancellationToken = new())
+  public Task<string> AddToCollectionAsync(string client, Guid collection, IArea area,
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Area, area, cancellationToken);
 
   /// <summary>Adds the specified areas to the specified collection.</summary>
@@ -164,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IArea> areas,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Area, areas, cancellationToken);
 
   /// <summary>Adds the specified areas to the specified collection.</summary>
@@ -198,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IArea area,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Area, area, cancellationToken);
 
   /// <summary>Adds the specified areas to the specified collection.</summary>
@@ -230,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IArea> areas,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Area, areas, cancellationToken);
 
   #endregion
@@ -358,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IArea area,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Area, area, cancellationToken);
 
   /// <summary>Removes the specified areas from the specified collection.</summary>
@@ -390,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IArea> areas,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Area, areas, cancellationToken);
 
   /// <summary>Removes the specified areas from the specified collection.</summary>
@@ -424,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IArea area,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Area, area, cancellationToken);
 
   /// <summary>Removes the specified areas from the specified collection.</summary>
@@ -456,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IArea> areas,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Area, areas, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Artists.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Artists.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IArtist artist,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Artist, artist, cancellationToken);
 
   /// <summary>Adds the specified artists to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IArtist> artists,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Artist, artists, cancellationToken);
 
   /// <summary>Adds the specified artists to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IArtist artist,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Artist, artist, cancellationToken);
 
   /// <summary>Adds the specified artists to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IArtist> artists,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Artist, artists, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IArtist artist,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Artist, artist, cancellationToken);
 
   /// <summary>Removes the specified artists from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IArtist> artists,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Artist, artists, cancellationToken);
 
   /// <summary>Removes the specified artists from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IArtist artist,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Artist, artist, cancellationToken);
 
   /// <summary>Removes the specified artists from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IArtist> artists,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Artist, artists, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Events.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Events.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEvent @event,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Event, @event, cancellationToken);
 
   /// <summary>Adds the specified events to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IEvent> events,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Event, events, cancellationToken);
 
   /// <summary>Adds the specified events to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEvent @event,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Event, @event, cancellationToken);
 
   /// <summary>Adds the specified events to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IEvent> events,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Event, events, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEvent @event,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Event, @event, cancellationToken);
 
   /// <summary>Removes the specified events from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IEvent> events,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Event, events, cancellationToken);
 
   /// <summary>Removes the specified events from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEvent @event,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Event, @event, cancellationToken);
 
   /// <summary>Removes the specified events from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IEvent> events,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Event, events, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Instruments.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Instruments.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IInstrument instrument,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Instrument, instrument, cancellationToken);
 
   /// <summary>Adds the specified instruments to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IInstrument> instruments,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Instrument, instruments, cancellationToken);
 
   /// <summary>Adds the specified instruments to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IInstrument instrument,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Instrument, instrument, cancellationToken);
 
   /// <summary>Adds the specified instruments to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IInstrument> instruments,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Instrument, instruments, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IInstrument instrument,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Instrument, instrument, cancellationToken);
 
   /// <summary>Removes the specified instruments from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IInstrument> instruments,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Instrument, instruments, cancellationToken);
 
   /// <summary>Removes the specified instruments from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IInstrument instrument,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Instrument, instrument, cancellationToken);
 
   /// <summary>Removes the specified instruments from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IInstrument> instruments,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Instrument, instruments, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Labels.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Labels.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, ILabel label,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Label, label, cancellationToken);
 
   /// <summary>Adds the specified labels to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<ILabel> labels,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Label, labels, cancellationToken);
 
   /// <summary>Adds the specified labels to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, ILabel label,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Label, label, cancellationToken);
 
   /// <summary>Adds the specified labels to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<ILabel> labels,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Label, labels, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, ILabel label,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Label, label, cancellationToken);
 
   /// <summary>Removes the specified labels from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<ILabel> labels,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Label, labels, cancellationToken);
 
   /// <summary>Removes the specified labels from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, ILabel label,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Label, label, cancellationToken);
 
   /// <summary>Removes the specified labels from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<ILabel> labels,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Label, labels, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Places.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Places.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IPlace place,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Place, place, cancellationToken);
 
   /// <summary>Adds the specified places to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IPlace> places,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Place, places, cancellationToken);
 
   /// <summary>Adds the specified places to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IPlace place,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Place, place, cancellationToken);
 
   /// <summary>Adds the specified places to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IPlace> places,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Place, places, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IPlace place,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Place, place, cancellationToken);
 
   /// <summary>Removes the specified places from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IPlace> places,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Place, places, cancellationToken);
 
   /// <summary>Removes the specified places from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IPlace place,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Place, place, cancellationToken);
 
   /// <summary>Removes the specified places from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IPlace> places,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Place, places, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Recordings.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Recordings.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IRecording recording,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Recording, recording, cancellationToken);
 
   /// <summary>Adds the specified recordings to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IRecording> recordings,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Recording, recordings, cancellationToken);
 
   /// <summary>Adds the specified recordings to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IRecording recording,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Recording, recording, cancellationToken);
 
   /// <summary>Adds the specified recordings to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IRecording> recordings,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Recording, recordings, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IRecording recording,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Recording, recording, cancellationToken);
 
   /// <summary>Removes the specified recordings from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IRecording> recordings,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Recording, recordings, cancellationToken);
 
   /// <summary>Removes the specified recordings from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IRecording recording,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Recording, recording, cancellationToken);
 
   /// <summary>Removes the specified recordings from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IRecording> recordings,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Recording, recordings, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.ReleaseGroups.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.ReleaseGroups.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IReleaseGroup releaseGroup,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroup, cancellationToken);
 
   /// <summary>Adds the specified release groups to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IReleaseGroup> releaseGroups,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroups, cancellationToken);
 
   /// <summary>Adds the specified release groups to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IReleaseGroup releaseGroup,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroup, cancellationToken);
 
   /// <summary>Adds the specified release groups to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IReleaseGroup> releaseGroups,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroups, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IReleaseGroup releaseGroup,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroup, cancellationToken);
 
   /// <summary>Removes the specified release groups from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IReleaseGroup> releaseGroups,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroups, cancellationToken);
 
   /// <summary>Removes the specified release groups from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IReleaseGroup releaseGroup,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroup, cancellationToken);
 
   /// <summary>Removes the specified release groups from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IReleaseGroup> releaseGroups,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.ReleaseGroup, releaseGroups, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Releases.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Releases.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IRelease release,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Release, release, cancellationToken);
 
   /// <summary>Adds the specified releases to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IRelease> releases,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Release, releases, cancellationToken);
 
   /// <summary>Adds the specified releases to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IRelease release,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Release, release, cancellationToken);
 
   /// <summary>Adds the specified releases to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IRelease> releases,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Release, releases, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IRelease release,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Release, release, cancellationToken);
 
   /// <summary>Removes the specified releases from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IRelease> releases,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Release, releases, cancellationToken);
 
   /// <summary>Removes the specified releases from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IRelease release,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Release, release, cancellationToken);
 
   /// <summary>Removes the specified releases from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IRelease> releases,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Release, releases, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Series.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Series.cs
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, ISeries series,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Adds the specified series to the specified collection.</summary>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<ISeries> series,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Adds the specified series to the specified collection.</summary>
@@ -199,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, ISeries series,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Adds the specified series to the specified collection.</summary>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<ISeries> series,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   #endregion
@@ -359,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, ISeries series,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Removes the specified series from the specified collection.</summary>
@@ -391,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<ISeries> series,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Removes the specified series from the specified collection.</summary>
@@ -425,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, ISeries series,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   /// <summary>Removes the specified series from the specified collection.</summary>
@@ -457,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<ISeries> series,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Series, series, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.Works.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.Works.cs
@@ -132,7 +132,8 @@ public sealed partial class Query {
   /// <exception cref="ArgumentException">When <paramref name="client"/> is blank.</exception>
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
-  public Task<string> AddToCollectionAsync(string client, Guid collection, IWork work, CancellationToken cancellationToken = new())
+  public Task<string> AddToCollectionAsync(string client, Guid collection, IWork work,
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Work, work, cancellationToken);
 
   /// <summary>Adds the specified works to the specified collection.</summary>
@@ -164,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, IEnumerable<IWork> works,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Work, works, cancellationToken);
 
   /// <summary>Adds the specified works to the specified collection.</summary>
@@ -198,7 +199,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IWork work,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Work, work, cancellationToken);
 
   /// <summary>Adds the specified works to the specified collection.</summary>
@@ -230,7 +231,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<IWork> works,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection, EntityType.Work, works, cancellationToken);
 
   #endregion
@@ -358,7 +359,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IWork work,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Work, work, cancellationToken);
 
   /// <summary>Removes the specified works from the specified collection.</summary>
@@ -390,7 +391,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, IEnumerable<IWork> works,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Work, works, cancellationToken);
 
   /// <summary>Removes the specified works from the specified collection.</summary>
@@ -424,7 +425,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IWork work,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Work, work, cancellationToken);
 
   /// <summary>Removes the specified works from the specified collection.</summary>
@@ -456,7 +457,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<IWork> works,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection, EntityType.Work, works, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Collections.cs
+++ b/MetaBrainz.MusicBrainz/Query.Collections.cs
@@ -140,7 +140,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, EntityType entityType, Guid item,
-                                           CancellationToken cancellationToken = new()) {
+                                           CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Put, client, collection, entityType).Add(item);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -162,7 +162,7 @@ public sealed partial class Query {
     => this.AddToCollectionAsync(client, collection, entityType, (IEnumerable<Guid>) items);
 
   private Task<string> AddToCollectionAsync(string client, Guid collection, EntityType entityType, IEntity item,
-                                            CancellationToken cancellationToken = new()) {
+                                            CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Put, client, collection, entityType).Add(item);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -182,13 +182,13 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, Guid collection, EntityType entityType, IEnumerable<Guid> items,
-                                           CancellationToken cancellationToken = new()) {
+                                           CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Put, client, collection, entityType).Add(items);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
 
   private Task<string> AddToCollectionAsync(string client, Guid collection, EntityType entityType, IEnumerable<IEntity> items,
-                                            CancellationToken cancellationToken = new()) {
+                                            CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Put, client, collection, entityType).Add(items);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -211,7 +211,7 @@ public sealed partial class Query {
     => this.AddToCollectionAsync(client, collection.Id, collection.ContentType, items, cancellationToken);
 
   private Task<string> AddToCollectionAsync(string client, ICollection collection, EntityType entityType, IEntity item,
-                                            CancellationToken cancellationToken = new()) {
+                                            CancellationToken cancellationToken = default) {
     var id = collection.Id;
     var type = collection.ContentType;
     if (type != entityType) {
@@ -221,7 +221,7 @@ public sealed partial class Query {
   }
 
   private Task<string> AddToCollectionAsync(string client, ICollection collection, EntityType entityType,
-                                            IEnumerable<IEntity> items, CancellationToken cancellationToken = new()) {
+                                            IEnumerable<IEntity> items, CancellationToken cancellationToken = default) {
     var id = collection.Id;
     var type = collection.ContentType;
     if (type != entityType) {
@@ -244,7 +244,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, Guid item,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection.Id, collection.ContentType, item, cancellationToken);
 
   /// <summary>Adds the specified items to the specified collection.</summary>
@@ -276,7 +276,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> AddToCollectionAsync(string client, ICollection collection, IEnumerable<Guid> items,
-                                           CancellationToken cancellationToken = new())
+                                           CancellationToken cancellationToken = default)
     => this.AddToCollectionAsync(client, collection.Id, collection.ContentType, items, cancellationToken);
 
   #endregion
@@ -409,7 +409,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, EntityType entityType, Guid item,
-                                                CancellationToken cancellationToken = new()) {
+                                                CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Delete, client, collection, entityType).Add(item);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -431,7 +431,7 @@ public sealed partial class Query {
     => this.RemoveFromCollectionAsync(client, collection, entityType, (IEnumerable<Guid>) items);
 
   private Task<string> RemoveFromCollectionAsync(string client, Guid collection, EntityType entityType, IEntity item,
-                                                 CancellationToken cancellationToken = new()) {
+                                                 CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Delete, client, collection, entityType).Add(item);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -451,13 +451,13 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, Guid collection, EntityType entityType, IEnumerable<Guid> items,
-                                                CancellationToken cancellationToken = new()) {
+                                                CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Delete, client, collection, entityType).Add(items);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
 
   private Task<string> RemoveFromCollectionAsync(string client, Guid collection, EntityType entityType, IEnumerable<IEntity> items,
-                                                 CancellationToken cancellationToken = new()) {
+                                                 CancellationToken cancellationToken = default) {
     var submission = new ModifyCollection(HttpMethod.Delete, client, collection, entityType).Add(items);
     return this.PerformSubmissionAsync(submission, cancellationToken);
   }
@@ -480,7 +480,7 @@ public sealed partial class Query {
     => this.RemoveFromCollectionAsync(client, collection.Id, collection.ContentType, items, cancellationToken);
 
   private Task<string> RemoveFromCollectionAsync(string client, ICollection collection, EntityType entityType, IEntity item,
-                                                 CancellationToken cancellationToken = new()) {
+                                                 CancellationToken cancellationToken = default) {
     var id = collection.Id;
     var type = collection.ContentType;
     if (type != entityType) {
@@ -490,7 +490,7 @@ public sealed partial class Query {
   }
 
   private Task<string> RemoveFromCollectionAsync(string client, ICollection collection, EntityType entityType,
-                                                 IEnumerable<IEntity> items, CancellationToken cancellationToken = new()) {
+                                                 IEnumerable<IEntity> items, CancellationToken cancellationToken = default) {
     var id = collection.Id;
     var type = collection.ContentType;
     if (type != entityType) {
@@ -513,7 +513,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, Guid item,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection.Id, collection.ContentType, item, cancellationToken);
 
   /// <summary>Removes the specified items from the specified collection.</summary>
@@ -545,7 +545,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the MusicBrainz web service reports an error.</exception>
   /// <exception cref="WebException">When the MusicBrainz web service could not be contacted.</exception>
   public Task<string> RemoveFromCollectionAsync(string client, ICollection collection, IEnumerable<Guid> items,
-                                                CancellationToken cancellationToken = new())
+                                                CancellationToken cancellationToken = default)
     => this.RemoveFromCollectionAsync(client, collection.Id, collection.ContentType, items, cancellationToken);
 
   #endregion

--- a/MetaBrainz.MusicBrainz/Query.Lookup.cs
+++ b/MetaBrainz.MusicBrainz/Query.Lookup.cs
@@ -29,7 +29,7 @@ public sealed partial class Query {
   /// <returns>The requested area.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IArea> LookupAreaAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IArea> LookupAreaAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Area>("area", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified artist.</summary>
@@ -63,7 +63,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IArtist> LookupArtistAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
-                                               ReleaseStatus? status = null, CancellationToken cancellationToken = new())
+                                               ReleaseStatus? status = null, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Artist>("artist", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -84,7 +84,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<ICollection> LookupCollectionAsync(Guid mbid, Include inc = Include.None,
-                                                       CancellationToken cancellationToken = new())
+                                                       CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Collection>("collection", mbid, Query.BuildExtraText(inc), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -133,7 +133,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IDiscIdLookupResult> LookupDiscIdAsync(string discid, int[]? toc = null, Include inc = Include.None,
                                                            bool allMediaFormats = false, bool noStubs = false,
-                                                           CancellationToken cancellationToken = new()) {
+                                                           CancellationToken cancellationToken = default) {
     var extra = Query.BuildExtraText(inc, toc, allMediaFormats, noStubs);
     return await this.PerformRequestAsync<DiscIdLookupResult>("discid", discid, extra, cancellationToken).ConfigureAwait(false);
   }
@@ -153,7 +153,7 @@ public sealed partial class Query {
   /// <returns>The requested event.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IEvent> LookupEventAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IEvent> LookupEventAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Event>("event", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified genre.</summary>
@@ -169,7 +169,7 @@ public sealed partial class Query {
   /// <returns>The requested genre.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IGenre> LookupGenreAsync(Guid mbid, CancellationToken cancellationToken = new())
+  public async Task<IGenre> LookupGenreAsync(Guid mbid, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Genre>("genre", mbid, string.Empty, cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified instrument.</summary>
@@ -189,7 +189,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IInstrument> LookupInstrumentAsync(Guid mbid, Include inc = Include.None,
-                                                       CancellationToken cancellationToken = new())
+                                                       CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Instrument>("instrument", mbid, Query.BuildExtraText(inc), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -208,7 +208,7 @@ public sealed partial class Query {
   /// <returns>The recordings associated with the requested ISRC.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IIsrc> LookupIsrcAsync(string isrc, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IIsrc> LookupIsrcAsync(string isrc, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Isrc>("isrc", isrc, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the works associated with the specified ISWC.</summary>
@@ -228,7 +228,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IReadOnlyList<IWork>> LookupIswcAsync(string iswc, Include inc = Include.None,
-                                                          CancellationToken cancellationToken = new()) {
+                                                          CancellationToken cancellationToken = default) {
     // This "lookup" behaves like a browse, except that it does not support offset/limit.
     var lookup = new IswcLookup(this, iswc, Query.BuildExtraText(inc));
     var results = await lookup.NextAsync(cancellationToken).ConfigureAwait(false);
@@ -264,7 +264,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<ILabel> LookupLabelAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
-                                             ReleaseStatus? status = null, CancellationToken cancellationToken = new())
+                                             ReleaseStatus? status = null, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Label>("label", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -283,7 +283,7 @@ public sealed partial class Query {
   /// <returns>The requested place.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IPlace> LookupPlaceAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IPlace> LookupPlaceAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Place>("place", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified recording.</summary>
@@ -315,7 +315,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IRecording> LookupRecordingAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
-                                                     ReleaseStatus? status = null, CancellationToken cancellationToken = new())
+                                                     ReleaseStatus? status = null, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Recording>("recording", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -334,7 +334,8 @@ public sealed partial class Query {
   /// <returns>The requested release.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IRelease> LookupReleaseAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IRelease> LookupReleaseAsync(Guid mbid, Include inc = Include.None,
+                                                 CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Release>("release", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified release group.</summary>
@@ -360,7 +361,7 @@ public sealed partial class Query {
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   public async Task<IReleaseGroup> LookupReleaseGroupAsync(Guid mbid, Include inc = Include.None, ReleaseStatus? status = null,
-                                                           CancellationToken cancellationToken = new())
+                                                           CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<ReleaseGroup>("release-group", mbid, Query.BuildExtraText(inc, status), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -379,7 +380,7 @@ public sealed partial class Query {
   /// <returns>The requested series.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<ISeries> LookupSeriesAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<ISeries> LookupSeriesAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Series>("series", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified URL.</summary>
@@ -405,7 +406,7 @@ public sealed partial class Query {
   /// <returns>The requested URL.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IUrl> LookupUrlAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IUrl> LookupUrlAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Url>("url", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified URL.</summary>
@@ -415,7 +416,7 @@ public sealed partial class Query {
   /// <returns>The requested URL.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IUrl> LookupUrlAsync(Uri resource, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IUrl> LookupUrlAsync(Uri resource, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Url>("url", null, Query.BuildExtraText(inc, resource), cancellationToken)
                  .ConfigureAwait(false);
 
@@ -434,7 +435,7 @@ public sealed partial class Query {
   /// <returns>The requested work.</returns>
   /// <exception cref="QueryException">When the web service reports an error.</exception>
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
-  public async Task<IWork> LookupWorkAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = new())
+  public async Task<IWork> LookupWorkAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
     => await this.PerformRequestAsync<Work>("work", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Annotations.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Annotations.cs
@@ -75,7 +75,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllAnnotations"/></remarks>
   public Task<ISearchResults<ISearchResult<IAnnotation>>> FindAnnotationsAsync(string query, int? limit = null, int? offset = null,
                                                                                bool simple = false,
-                                                                               CancellationToken cancellationToken = new())
+                                                                               CancellationToken cancellationToken = default)
     => new FoundAnnotations(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Areas.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Areas.cs
@@ -82,7 +82,8 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   /// <remarks><inheritdoc cref="FindAllAreas"/></remarks>
   public Task<ISearchResults<ISearchResult<IArea>>> FindAreasAsync(string query, int? limit = null, int? offset = null,
-                                                                   bool simple = false, CancellationToken cancellationToken = new())
+                                                                   bool simple = false,
+                                                                   CancellationToken cancellationToken = default)
     => new FoundAreas(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Artists.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Artists.cs
@@ -91,7 +91,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllArtists"/></remarks>
   public Task<ISearchResults<ISearchResult<IArtist>>> FindArtistsAsync(string query, int? limit = null, int? offset = null,
                                                                        bool simple = false,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new FoundArtists(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.CdStubs.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.CdStubs.cs
@@ -77,7 +77,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllCdStubs"/></remarks>
   public Task<ISearchResults<ISearchResult<ICdStub>>> FindCdStubsAsync(string query, int? limit = null, int? offset = null,
                                                                        bool simple = false,
-                                                                       CancellationToken cancellationToken = new())
+                                                                       CancellationToken cancellationToken = default)
     => new FoundCdStubs(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Events.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Events.cs
@@ -82,7 +82,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllEvents"/></remarks>
   public Task<ISearchResults<ISearchResult<IEvent>>> FindEventsAsync(string query, int? limit = null, int? offset = null,
                                                                      bool simple = false,
-                                                                     CancellationToken cancellationToken = new())
+                                                                     CancellationToken cancellationToken = default)
     => new FoundEvents(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Instruments.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Instruments.cs
@@ -78,7 +78,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllInstruments"/></remarks>
   public Task<ISearchResults<ISearchResult<IInstrument>>> FindInstrumentsAsync(string query, int? limit = null, int? offset = null,
                                                                                bool simple = false,
-                                                                               CancellationToken cancellationToken = new())
+                                                                               CancellationToken cancellationToken = default)
     => new FoundInstruments(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Labels.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Labels.cs
@@ -88,7 +88,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllLabels"/></remarks>
   public Task<ISearchResults<ISearchResult<ILabel>>> FindLabelsAsync(string query, int? limit = null, int? offset = null,
                                                                      bool simple = false,
-                                                                     CancellationToken cancellationToken = new())
+                                                                     CancellationToken cancellationToken = default)
     => new FoundLabels(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Places.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Places.cs
@@ -84,7 +84,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllPlaces"/></remarks>
   public Task<ISearchResults<ISearchResult<IPlace>>> FindPlacesAsync(string query, int? limit = null, int? offset = null,
                                                                      bool simple = false,
-                                                                     CancellationToken cancellationToken = new())
+                                                                     CancellationToken cancellationToken = default)
     => new FoundPlaces(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Recordings.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Recordings.cs
@@ -132,7 +132,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllRecordings"/></remarks>
   public Task<ISearchResults<ISearchResult<IRecording>>> FindRecordingsAsync(string query, int? limit = null, int? offset = null,
                                                                              bool simple = false,
-                                                                             CancellationToken cancellationToken = new())
+                                                                             CancellationToken cancellationToken = default)
     => new FoundRecordings(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.ReleaseGroups.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.ReleaseGroups.cs
@@ -95,7 +95,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllReleaseGroups"/></remarks>
   public Task<ISearchResults<ISearchResult<IReleaseGroup>>> FindReleaseGroupsAsync(string query, int? limit = null,
                                                                                    int? offset = null, bool simple = false,
-                                                                                   CancellationToken cancellationToken = new())
+                                                                                   CancellationToken cancellationToken = default)
     => new FoundReleaseGroups(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Releases.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Releases.cs
@@ -109,7 +109,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllReleases"/></remarks>
   public Task<ISearchResults<ISearchResult<IRelease>>> FindReleasesAsync(string query, int? limit = null, int? offset = null,
                                                                          bool simple = false,
-                                                                         CancellationToken cancellationToken = new())
+                                                                         CancellationToken cancellationToken = default)
     => new FoundReleases(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Series.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Series.cs
@@ -76,7 +76,7 @@ public sealed partial class Query {
   /// <remarks><inheritdoc cref="FindAllSeries"/></remarks>
   public Task<ISearchResults<ISearchResult<ISeries>>> FindSeriesAsync(string query, int? limit = null, int? offset = null,
                                                                       bool simple = false,
-                                                                      CancellationToken cancellationToken = new())
+                                                                      CancellationToken cancellationToken = default)
     => new FoundSeries(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Tags.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Tags.cs
@@ -73,7 +73,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   /// <remarks><inheritdoc cref="FindAllTags"/></remarks>
   public Task<ISearchResults<ISearchResult<ITag>>> FindTagsAsync(string query, int? limit = null, int? offset = null,
-                                                                 bool simple = false, CancellationToken cancellationToken = new())
+                                                                 bool simple = false, CancellationToken cancellationToken = default)
     => new FoundTags(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Urls.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Urls.cs
@@ -73,7 +73,7 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   /// <remarks><inheritdoc cref="FindAllUrls"/></remarks>
   public Task<ISearchResults<ISearchResult<IUrl>>> FindUrlsAsync(string query, int? limit = null, int? offset = null,
-                                                                 bool simple = false, CancellationToken cancellationToken = new())
+                                                                 bool simple = false, CancellationToken cancellationToken = default)
     => new FoundUrls(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Search.Works.cs
+++ b/MetaBrainz.MusicBrainz/Query.Search.Works.cs
@@ -80,7 +80,8 @@ public sealed partial class Query {
   /// <exception cref="WebException">When something goes wrong with the web request.</exception>
   /// <remarks><inheritdoc cref="FindAllWorks"/></remarks>
   public Task<ISearchResults<ISearchResult<IWork>>> FindWorksAsync(string query, int? limit = null, int? offset = null,
-                                                                   bool simple = false, CancellationToken cancellationToken = new())
+                                                                   bool simple = false,
+                                                                   CancellationToken cancellationToken = default)
     => new FoundWorks(this, query, limit, offset, simple).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Utils.cs
+++ b/MetaBrainz.MusicBrainz/Utils.cs
@@ -20,7 +20,7 @@ internal static class Utils {
                                                                         CancellationToken cancellationToken = new()) {
     string? errorInfo = null;
     if (response.Content.Headers.ContentLength > 0) {
-      errorInfo = await Utils.GetStringContentAsync(response, cancellationToken);
+      errorInfo = await Utils.GetStringContentAsync(response, cancellationToken).ConfigureAwait(false);
       if (string.IsNullOrWhiteSpace(errorInfo)) {
         Debug.Print($"[{DateTime.UtcNow}] => NO ERROR RESPONSE TEXT");
         errorInfo = null;
@@ -109,13 +109,13 @@ internal static class Utils {
     var content = response.Content;
     Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({content.Headers.ContentType}): {content.Headers.ContentLength} bytes");
 #if NET
-    var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+    var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
     await using var _ = stream.ConfigureAwait(false);
 #elif NETSTANDARD2_1_OR_GREATER
-    var stream = await response.Content.ReadAsStreamAsync();
+    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
     await using var _ = stream.ConfigureAwait(false);
 #else
-    using var stream = await content.ReadAsStreamAsync();
+    using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
     if (stream is null || stream.Length == 0) {
       throw new QueryException(HttpStatusCode.NoContent, "Response contained no data.");
@@ -123,7 +123,7 @@ internal static class Utils {
     var characterSet = Utils.GetContentEncoding(content.Headers);
 #if !DEBUG
     if (characterSet == "utf-8") { // Directly use the stream
-      var jsonObject = await JsonSerializer.DeserializeAsync<T>(stream, options, cancellationToken);
+      var jsonObject = await JsonSerializer.DeserializeAsync<T>(stream, options, cancellationToken).ConfigureAwait(false);
       return jsonObject ?? throw new JsonException("The received content was null.");
     }
 #endif
@@ -143,13 +143,13 @@ internal static class Utils {
     var content = response.Content;
     Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({content.Headers.ContentType}): {content.Headers.ContentLength} bytes");
 #if NET
-    var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+    var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
     await using var _ = stream.ConfigureAwait(false);
 #elif NETSTANDARD2_1_OR_GREATER
-    var stream = await response.Content.ReadAsStreamAsync();
+    var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
     await using var _ = stream.ConfigureAwait(false);
 #else
-    using var stream = await response.Content.ReadAsStreamAsync();
+    using var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
 #if !NET
     if (stream is null) {

--- a/MetaBrainz.MusicBrainz/Utils.cs
+++ b/MetaBrainz.MusicBrainz/Utils.cs
@@ -17,7 +17,7 @@ namespace MetaBrainz.MusicBrainz;
 internal static class Utils {
 
   public static async Task<QueryException> CreateQueryExceptionForAsync(HttpResponseMessage response,
-                                                                        CancellationToken cancellationToken = new()) {
+                                                                        CancellationToken cancellationToken = default) {
     string? errorInfo = null;
     if (response.Content.Headers.ContentLength > 0) {
       errorInfo = await Utils.GetStringContentAsync(response, cancellationToken).ConfigureAwait(false);
@@ -105,7 +105,7 @@ internal static class Utils {
   }
 
   public static async Task<T> GetJsonContentAsync<T>(HttpResponseMessage response, JsonSerializerOptions options,
-                                                     CancellationToken cancellationToken = new()) {
+                                                     CancellationToken cancellationToken = default) {
     var content = response.Content;
     Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({content.Headers.ContentType}): {content.Headers.ContentLength} bytes");
 #if NET
@@ -139,7 +139,7 @@ internal static class Utils {
   }
 
   public static async Task<string> GetStringContentAsync(HttpResponseMessage response,
-                                                         CancellationToken cancellationToken = new()) {
+                                                         CancellationToken cancellationToken = default) {
     var content = response.Content;
     Debug.Print($"[{DateTime.UtcNow}] => RESPONSE ({content.Headers.ContentType}): {content.Headers.ContentLength} bytes");
 #if NET


### PR DESCRIPTION
This drops the use of a client lock (not needed for `HttpClient`), and ensures all internally-awaited tasks use `ConfigureAwait(false)`.