### PR TITLE
Add a `RateLimitInfo` property to `Query`

### DIFF
--- a/MetaBrainz.MusicBrainz/Query.Internals.cs
+++ b/MetaBrainz.MusicBrainz/Query.Internals.cs
@@ -532,6 +532,14 @@ public sealed partial class Query : IDisposable {
     Debug.Print($"[{DateTime.UtcNow}] => HEADERS: {TextUtils.FormatMultiLine(response.Headers.ToString())}");
     Debug.Print($"[{DateTime.UtcNow}] => CONTENT ({response.Content.Headers.ContentType}): " +
                 $"{response.Content.Headers.ContentLength ?? 0} bytes");
+    var rateLimitInfo = new RateLimitInfo(response.Headers);
+    this._rateLimitLock.EnterWriteLock();
+    try {
+      this._rateLimitInfo = rateLimitInfo;
+    }
+    finally {
+      this._rateLimitLock.ExitWriteLock();
+    }
     if (!response.IsSuccessStatusCode) {
       throw await QueryException.FromResponseAsync(response, cancellationToken).ConfigureAwait(false);
     }


### PR DESCRIPTION
This provides information from response headers that can help regulate volume of requests, particularly when setting the request delay to 0.