### PR TITLE
Rework request query string handling

### DIFF
--- a/MetaBrainz.MusicBrainz/Include.cs
+++ b/MetaBrainz.MusicBrainz/Include.cs
@@ -150,6 +150,14 @@ public enum Include : long {
   /// <summary>Include information about relationships with works.</summary>
   WorkRelationships = 1L << 53,
 
+  /// <summary>Include information about relationships involving the release groups associated with the release.</summary>
+  /// <remarks>
+  /// Only valid on queries for releases. Will have no real effect unless information about related release groups (via
+  /// <see cref="ReleaseGroups"/>) and one or more relationships (via <see cref="ArtistRelationships"/>,
+  /// <see cref="WorkRelationships"/>, ...) is being requested at the same time.
+  /// </remarks>
+  ReleaseGroupLevelRelationships = 1L << 54,
+
   #endregion
 
 }

--- a/MetaBrainz.MusicBrainz/MetaBrainz.MusicBrainz.csproj
+++ b/MetaBrainz.MusicBrainz/MetaBrainz.MusicBrainz.csproj
@@ -11,7 +11,7 @@
     <PackageCopyrightYears>2016-2023</PackageCopyrightYears>
     <PackageRepositoryName>MetaBrainz.MusicBrainz</PackageRepositoryName>
     <PackageTags>MusicBrainz music metadata libmusicbrainz OAuth2</PackageTags>
-    <Version>6.0.1-pre</Version>
+    <Version>6.1.0-pre</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseAreas.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseAreas.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseAreas : BrowseResults<IArea> {
 
-  public BrowseAreas(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "area", null, extra, limit, offset) {
+  public BrowseAreas(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                     int? offset) : base(query, "area", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IArea> Results => this.CurrentResult?.Areas ?? Array.Empty<IArea>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseArtists.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseArtists.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseArtists : BrowseResults<IArtist> {
 
-  public BrowseArtists(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "artist", null, extra, limit, offset) {
+  public BrowseArtists(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                       int? offset) : base(query, "artist", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IArtist> Results => this.CurrentResult?.Artists ?? Array.Empty<IArtist>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseCollections.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseCollections.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseCollections : BrowseResults<ICollection> {
 
-  public BrowseCollections(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "collection", null, extra, limit, offset) {
+  public BrowseCollections(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                           int? offset) : base(query, "collection", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<ICollection> Results => this.CurrentResult?.Collections ?? Array.Empty<ICollection>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseEvents.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseEvents.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseEvents : BrowseResults<IEvent> {
 
-  public BrowseEvents(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "event", null, extra, limit, offset) {
+  public BrowseEvents(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                      int? offset) : base(query, "event", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IEvent> Results => this.CurrentResult?.Events ?? Array.Empty<IEvent>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseInstruments.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseInstruments.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseInstruments : BrowseResults<IInstrument> {
 
-  public BrowseInstruments(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "instrument", null, extra, limit, offset) {
+  public BrowseInstruments(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                           int? offset) : base(query, "instrument", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IInstrument> Results => this.CurrentResult?.Instruments ?? Array.Empty<IInstrument>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseLabels.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseLabels.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseLabels : BrowseResults<ILabel> {
 
-  public BrowseLabels(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "label", null, extra, limit, offset) {
+  public BrowseLabels(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                      int? offset) : base(query, "label", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<ILabel> Results => this.CurrentResult?.Labels ?? Array.Empty<ILabel>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowsePlaces.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowsePlaces.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowsePlaces : BrowseResults<IPlace> {
 
-  public BrowsePlaces(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "place", null, extra, limit, offset) {
+  public BrowsePlaces(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                      int? offset) : base(query, "place", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IPlace> Results => this.CurrentResult?.Places ?? Array.Empty<IPlace>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseRecordings.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseRecordings.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseRecordings : BrowseResults<IRecording> {
 
-  public BrowseRecordings(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "recording", null, extra, limit, offset) {
+  public BrowseRecordings(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                          int? offset) : base(query, "recording", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IRecording> Results => this.CurrentResult?.Recordings ?? Array.Empty<IRecording>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseReleaseGroups.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseReleaseGroups.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseReleaseGroups : BrowseResults<IReleaseGroup> {
 
-  public BrowseReleaseGroups(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "release-group", null, extra, limit, offset) {
+  public BrowseReleaseGroups(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                             int? offset) : base(query, "release-group", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IReleaseGroup> Results => this.CurrentResult?.ReleaseGroups ?? Array.Empty<IReleaseGroup>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseReleases.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseReleases.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseReleases : BrowseResults<IRelease> {
 
-  public BrowseReleases(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "release", null, extra, limit, offset) {
+  public BrowseReleases(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                        int? offset) : base(query, "release", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<IRelease> Results => this.CurrentResult?.Releases ?? Array.Empty<IRelease>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseSeries.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseSeries.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseSeries : BrowseResults<ISeries> {
 
-  public BrowseSeries(Query query, string extra, int? limit = null, int? offset = null)
-    : base(query, "series", null, extra, limit, offset) {
+  public BrowseSeries(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                      int? offset) : base(query, "series", null, options, limit, offset) {
   }
 
   public override IReadOnlyList<ISeries> Results => this.CurrentResult?.Series ?? Array.Empty<ISeries>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseWorks.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseWorks.cs
@@ -1,9 +1,11 @@
-﻿namespace MetaBrainz.MusicBrainz.Objects.Browses;
+﻿using System.Collections.Generic;
+
+namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseWorks : BrowseWorksBase {
 
-  public BrowseWorks(Query query, string extra, int? limit, int? offset)
-    : base(query, "work", null, extra, limit, offset) {
+  public BrowseWorks(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                     int? offset) : base(query, "work", null, options, limit, offset) {
   }
 
 }

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseWorksBase.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseWorksBase.cs
@@ -7,8 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal abstract class BrowseWorksBase : BrowseResults<IWork> {
 
-  protected BrowseWorksBase(Query query, string endpoint, string? value, string extra, int? limit = null, int? offset = null)
-    : base(query, endpoint, value, extra, limit, offset) {
+  protected BrowseWorksBase(Query query, string endpoint, string? value, IReadOnlyDictionary<string, string>? options,
+                            int? limit = null, int? offset = null) : base(query, endpoint, value, options, limit, offset) {
   }
 
   public sealed override IReadOnlyList<IWork> Results => this.CurrentResult?.Works ?? Array.Empty<IWork>();

--- a/MetaBrainz.MusicBrainz/Objects/Browses/IswcLookup.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/IswcLookup.cs
@@ -1,9 +1,10 @@
-﻿namespace MetaBrainz.MusicBrainz.Objects.Browses;
+﻿using System.Collections.Generic;
+
+namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class IswcLookup : BrowseWorksBase {
 
-  public IswcLookup(Query query, string iswc, string extra)
-    : base(query, "iswc", iswc, extra) {
+  public IswcLookup(Query query, string iswc, IReadOnlyDictionary<string, string> options) : base(query, "iswc", iswc, options) {
   }
 
 }

--- a/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
+++ b/MetaBrainz.MusicBrainz/Objects/PagedQueryResults.cs
@@ -62,7 +62,7 @@ where TResultObject : class {
 
   protected abstract Task<TResults> DeserializeAsync(HttpResponseMessage response, CancellationToken cancellationToken);
 
-  protected abstract string FullExtraText();
+  protected abstract IReadOnlyDictionary<string, string> FullOptions();
 
   #endregion
 
@@ -75,7 +75,7 @@ where TResultObject : class {
   private readonly string? _value;
 
   private async Task<TResults> PerformRequestAsync(CancellationToken cancellationToken) {
-    var task = this._query.PerformRequestAsync(this._endpoint, this._value, this.FullExtraText(), cancellationToken);
+    var task = this._query.PerformRequestAsync(this._endpoint, this._value, this.FullOptions(), cancellationToken);
     var response = await task.ConfigureAwait(false);
     return await this.DeserializeAsync(response, cancellationToken).ConfigureAwait(false);
   }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Areas.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Areas.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArea> BrowseAllAreas(ICollection collection, int? pageSize = null, int? offset = null,
                                                       Include inc = Include.None)
-    => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseAreas(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the areas in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained areas should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArea> BrowseAllCollectionAreas(Guid mbid, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None)
-    => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseAreas(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the areas in the given collection.</summary>
   /// <param name="collection">The collection whose contained areas should be retrieved.</param>
@@ -70,7 +70,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArea>> BrowseAreasAsync(ICollection collection, int? limit = null, int? offset = null,
                                                       Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseAreas(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the areas in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained areas should be retrieved.</param>
@@ -95,6 +95,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArea>> BrowseCollectionAreasAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
                                                                 CancellationToken cancellationToken = default)
-    => new BrowseAreas(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseAreas(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Artists.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Artists.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllAreaArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                               Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "area", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("area", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given area.</summary>
   /// <param name="area">The area whose artists should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(IArea area, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "area", area.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("area", area.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
   /// <param name="collection">The collection whose contained artists should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(ICollection collection, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given recording.</summary>
   /// <param name="recording">The recording whose artists should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(IRecording recording, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", recording.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("recording", recording.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release.</summary>
   /// <param name="release">The release whose artists should be retrieved.</param>
@@ -96,7 +96,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(IRelease release, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release", release.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("release", release.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release group.</summary>
   /// <param name="releaseGroup">The release group whose artists should be retrieved.</param>
@@ -113,7 +113,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(IReleaseGroup releaseGroup, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("release-group", releaseGroup.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given work.</summary>
   /// <param name="work">The work whose artists should be retrieved.</param>
@@ -130,7 +130,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllArtists(IWork work, int? pageSize = null, int? offset = null,
                                                           Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "work", work.Id), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("work", work.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained artists should be retrieved.</param>
@@ -147,7 +147,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllCollectionArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                                     Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists associated with the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose artists should be retrieved.</param>
@@ -164,7 +164,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllRecordingArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                                    Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("recording", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose artists should be retrieved.</param>
@@ -181,7 +181,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllReleaseArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                                  Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("release", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release group.</summary>
   /// <param name="mbid">The MBID for the release group whose artists should be retrieved.</param>
@@ -198,7 +198,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllReleaseGroupArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                                       Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("release-group", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists associated with the given work.</summary>
   /// <param name="mbid">The MBID for the work whose artists should be retrieved.</param>
@@ -215,7 +215,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IArtist> BrowseAllWorkArtists(Guid mbid, int? pageSize = null, int? offset = null,
                                                               Include inc = Include.None)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "work", mbid), pageSize, offset).AsStream();
+    => new BrowseArtists(this, Query.CreateOptions("work", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the artists associated with the given area.</summary>
   /// <param name="mbid">The MBID for the area whose artists should be retrieved.</param>
@@ -240,7 +240,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseAreaArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
                                                               CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("area", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given area.</summary>
   /// <param name="area">The area whose artists should be retrieved.</param>
@@ -322,7 +322,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IArea area, int? limit = null, int? offset = null,
                                                           Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("area", area.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
   /// <param name="collection">The collection whose contained artists should be retrieved.</param>
@@ -335,7 +335,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                           Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given recording.</summary>
   /// <param name="recording">The recording whose artists should be retrieved.</param>
@@ -348,7 +348,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IRecording recording, int? limit = null, int? offset = null,
                                                           Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", recording.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("recording", recording.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release.</summary>
   /// <param name="release">The release whose artists should be retrieved.</param>
@@ -361,7 +361,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IRelease release, int? limit = null, int? offset = null,
                                                           Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("release", release.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given release group.</summary>
   /// <param name="releaseGroup">The release group whose artists should be retrieved.</param>
@@ -375,7 +375,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
                                                           Include inc = Include.None,
                                                           CancellationToken cancellationToken = default) {
-    var browse = new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id), limit, offset);
+    var browse = new BrowseArtists(this, Query.CreateOptions("release-group", releaseGroup.Id, inc), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -390,7 +390,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IArtist>> BrowseArtistsAsync(IWork work, int? limit = null, int? offset = null,
                                                           Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "work", work.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("work", work.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained artists should be retrieved.</param>
@@ -416,7 +416,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseCollectionArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                     Include inc = Include.None,
                                                                     CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose artists should be retrieved.</param>
@@ -442,7 +442,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseRecordingArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                    Include inc = Include.None,
                                                                    CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "recording", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("recording", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose artists should be retrieved.</param>
@@ -467,7 +467,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseReleaseArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                  Include inc = Include.None,
                                                                  CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("release", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given release group.</summary>
   /// <param name="mbid">The MBID for the release group whose artists should be retrieved.</param>
@@ -493,7 +493,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseReleaseGroupArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None,
                                                                       CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "release-group", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("release-group", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the artists associated with the given work.</summary>
   /// <param name="mbid">The MBID for the work whose artists should be retrieved.</param>
@@ -518,6 +518,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<IArtist>> BrowseWorkArtistsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
                                                               CancellationToken cancellationToken = default)
-    => new BrowseArtists(this, Query.BuildExtraText(inc, "work", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseArtists(this, Query.CreateOptions("work", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Collections.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Collections.cs
@@ -26,7 +26,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllAreaCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("area", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("area", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose containing collections should be retrieved.</param>
@@ -41,7 +41,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllArtistCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("artist", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("artist", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given area.</summary>
   /// <param name="area">The area whose containing collections should be retrieved.</param>
@@ -56,7 +56,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IArea area, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("area", area.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("area", area.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given artist.</summary>
   /// <param name="artist">The artist whose containing collections should be retrieved.</param>
@@ -71,7 +71,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IArtist artist, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("artist", artist.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("artist", artist.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given event.</summary>
   /// <param name="event">The event whose containing collections should be retrieved.</param>
@@ -86,7 +86,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IEvent @event, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("event", @event.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("event", @event.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given instrument.</summary>
   /// <param name="instrument">The instrument whose containing collections should be retrieved.</param>
@@ -101,7 +101,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IInstrument instrument, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("instrument", instrument.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("instrument", instrument.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given label.</summary>
   /// <param name="label">The label whose containing collections should be retrieved.</param>
@@ -116,7 +116,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(ILabel label, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("label", label.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("label", label.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given place.</summary>
   /// <param name="place">The place whose containing collections should be retrieved.</param>
@@ -131,7 +131,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IPlace place, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("place", place.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("place", place.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given recording.</summary>
   /// <param name="recording">The recording whose containing collections should be retrieved.</param>
@@ -146,7 +146,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IRecording recording, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("recording", recording.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("recording", recording.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given release.</summary>
   /// <param name="release">The release whose containing collections should be retrieved.</param>
@@ -161,7 +161,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IRelease release, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("release", release.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("release", release.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given release group.</summary>
   /// <param name="releaseGroup">The release group whose containing collections should be retrieved.</param>
@@ -177,7 +177,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IReleaseGroup releaseGroup, int? pageSize = null,
                                                                   int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("release-group", releaseGroup.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("release-group", releaseGroup.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given series.</summary>
   /// <param name="series">The series whose containing collections should be retrieved.</param>
@@ -192,7 +192,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(ISeries series, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("series", series.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("series", series.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given work.</summary>
   /// <param name="work">The work whose containing collections should be retrieved.</param>
@@ -207,7 +207,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllCollections(IWork work, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("work", work.Id), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("work", work.Id), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections of the given editor.</summary>
   /// <param name="editor">The editor whose collections should be retrieved.</param>
@@ -222,7 +222,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllEditorCollections(string editor, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("editor", editor), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("editor", editor), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given event.</summary>
   /// <param name="mbid">The MBID for the event whose containing collections should be retrieved.</param>
@@ -237,7 +237,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllEventCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("event", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("event", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given instrument.</summary>
   /// <param name="mbid">The MBID for the instrument whose containing collections should be retrieved.</param>
@@ -252,7 +252,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllInstrumentCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("instrument", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("instrument", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given label.</summary>
   /// <param name="mbid">The MBID for the label whose containing collections should be retrieved.</param>
@@ -267,7 +267,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllLabelCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("label", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("label", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given place.</summary>
   /// <param name="mbid">The MBID for the place whose containing collections should be retrieved.</param>
@@ -282,7 +282,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllPlaceCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("place", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("place", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose containing collections should be retrieved.</param>
@@ -297,7 +297,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllRecordingCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("recording", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("recording", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given release.</summary>
   /// <param name="mbid">The MBID for the release whose containing collections should be retrieved.</param>
@@ -312,7 +312,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllReleaseCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("release", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("release", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given release group.</summary>
   /// <param name="mbid">The MBID for the release group whose containing collections should be retrieved.</param>
@@ -327,7 +327,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllReleaseGroupCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("release-group", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("release-group", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given series.</summary>
   /// <param name="mbid">The MBID for the series whose containing collections should be retrieved.</param>
@@ -342,7 +342,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllSeriesCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("series", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("series", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns the collections that include the given work.</summary>
   /// <param name="mbid">The MBID for the work whose containing collections should be retrieved.</param>
@@ -357,7 +357,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ICollection> BrowseAllWorkCollections(Guid mbid, int? pageSize = null, int? offset = null)
-    => new BrowseCollections(this, Query.BuildExtraText("work", mbid), pageSize, offset).AsStream();
+    => new BrowseCollections(this, Query.CreateOptions("work", mbid), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the collections that include the given area.</summary>
   /// <param name="mbid">The MBID for the area whose containing collections should be retrieved.</param>
@@ -379,7 +379,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseAreaCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("area", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("area", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose containing collections should be retrieved.</param>
@@ -401,7 +401,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseArtistCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                         CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("artist", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("artist", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given area.</summary>
   /// <param name="area">The area whose containing collections should be retrieved.</param>
@@ -523,7 +523,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IArea area, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("area", area.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("area", area.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given artist.</summary>
   /// <param name="artist">The artist whose containing collections should be retrieved.</param>
@@ -535,7 +535,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("artist", artist.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("artist", artist.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given event.</summary>
   /// <param name="event">The event whose containing collections should be retrieved.</param>
@@ -547,7 +547,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IEvent @event, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("event", @event.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("event", @event.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given instrument.</summary>
   /// <param name="instrument">The instrument whose containing collections should be retrieved.</param>
@@ -559,7 +559,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IInstrument instrument, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("instrument", instrument.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("instrument", instrument.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given label.</summary>
   /// <param name="label">The label whose containing collections should be retrieved.</param>
@@ -571,7 +571,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(ILabel label, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("label", label.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("label", label.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given place.</summary>
   /// <param name="place">The place whose containing collections should be retrieved.</param>
@@ -583,7 +583,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IPlace place, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("place", place.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("place", place.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given recording.</summary>
   /// <param name="recording">The recording whose containing collections should be retrieved.</param>
@@ -595,7 +595,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IRecording recording, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("recording", recording.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("recording", recording.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release.</summary>
   /// <param name="release">The release whose containing collections should be retrieved.</param>
@@ -607,7 +607,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IRelease release, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("release", release.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("release", release.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release group.</summary>
   /// <param name="releaseGroup">The release group whose containing collections should be retrieved.</param>
@@ -619,7 +619,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default) {
-    var browse = new BrowseCollections(this, Query.BuildExtraText("release-group", releaseGroup.Id), limit, offset);
+    var browse = new BrowseCollections(this, Query.CreateOptions("release-group", releaseGroup.Id), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -633,7 +633,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(ISeries series, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("series", series.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("series", series.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given work.</summary>
   /// <param name="work">The work whose containing collections should be retrieved.</param>
@@ -645,7 +645,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseCollectionsAsync(IWork work, int? limit = null, int? offset = null,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("work", work.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("work", work.Id), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections of the given editor.</summary>
   /// <param name="editor">The editor whose collections should be retrieved.</param>
@@ -667,7 +667,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseEditorCollectionsAsync(string editor, int? limit = null, int? offset = null,
                                                                         CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("editor", editor), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("editor", editor), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given event.</summary>
   /// <param name="mbid">The MBID for the event whose containing collections should be retrieved.</param>
@@ -689,7 +689,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseEventCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("event", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("event", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given instrument.</summary>
   /// <param name="mbid">The MBID for the instrument whose containing collections should be retrieved.</param>
@@ -711,7 +711,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseInstrumentCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                             CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("instrument", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("instrument", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given label.</summary>
   /// <param name="mbid">The MBID for the label whose containing collections should be retrieved.</param>
@@ -733,7 +733,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseLabelCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("label", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("label", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given place.</summary>
   /// <param name="mbid">The MBID for the place whose containing collections should be retrieved.</param>
@@ -755,7 +755,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowsePlaceCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("place", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("place", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose containing collections should be retrieved.</param>
@@ -777,7 +777,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseRecordingCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                            CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("recording", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("recording", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release.</summary>
   /// <param name="mbid">The MBID for the release whose containing collections should be retrieved.</param>
@@ -799,7 +799,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseReleaseCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                          CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("release", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("release", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given release group.</summary>
   /// <param name="mbid">The MBID for the release group whose containing collections should be retrieved.</param>
@@ -821,7 +821,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseReleaseGroupCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                               CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("release-group", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("release-group", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given series.</summary>
   /// <param name="mbid">The MBID for the series whose containing collections should be retrieved.</param>
@@ -843,7 +843,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseSeriesCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                         CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("series", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("series", mbid), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the collections that include the given work.</summary>
   /// <param name="mbid">The MBID for the work whose containing collections should be retrieved.</param>
@@ -865,6 +865,6 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ICollection>> BrowseWorkCollectionsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       CancellationToken cancellationToken = default)
-    => new BrowseCollections(this, Query.BuildExtraText("work", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseCollections(this, Query.CreateOptions("work", mbid), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Events.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Events.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllAreaEvents(Guid mbid, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "area", mbid), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("area", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose events should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllArtistEvents(Guid mbid, int? pageSize = null, int? offset = null,
                                                               Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", mbid), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("artist", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose events should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllCollectionEvents(Guid mbid, int? pageSize = null, int? offset = null,
                                                                   Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events associated with the given area.</summary>
   /// <param name="area">The area whose events should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllEvents(IArea area, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "area", area.Id), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("area", area.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events associated with the given artist.</summary>
   /// <param name="artist">The artist whose events should be retrieved.</param>
@@ -96,7 +96,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllEvents(IArtist artist, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", artist.Id), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("artist", artist.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events in the given collection.</summary>
   /// <param name="collection">The collection whose contained events should be retrieved.</param>
@@ -113,7 +113,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllEvents(ICollection collection, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events associated with the given place.</summary>
   /// <param name="place">The place whose events should be retrieved.</param>
@@ -130,7 +130,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllEvents(IPlace place, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "place", place.Id), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("place", place.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the events associated with the given place.</summary>
   /// <param name="mbid">The MBID for the place whose events should be retrieved.</param>
@@ -147,7 +147,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IEvent> BrowseAllPlaceEvents(Guid mbid, int? pageSize = null, int? offset = null,
                                                              Include inc = Include.None)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "place", mbid), pageSize, offset).AsStream();
+    => new BrowseEvents(this, Query.CreateOptions("place", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the events associated with the given area.</summary>
   /// <param name="mbid">The MBID for the area whose events should be retrieved.</param>
@@ -172,7 +172,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IEvent>> BrowseAreaEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                             Include inc = Include.None,
                                                             CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("area", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose events should be retrieved.</param>
@@ -197,7 +197,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IEvent>> BrowseArtistEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                               Include inc = Include.None,
                                                               CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("artist", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained events should be retrieved.</param>
@@ -222,7 +222,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IEvent>> BrowseCollectionEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given area.</summary>
   /// <param name="area">The area whose events should be retrieved.</param>
@@ -280,7 +280,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IArea area, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("area", area.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given artist.</summary>
   /// <param name="artist">The artist whose events should be retrieved.</param>
@@ -293,7 +293,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("artist", artist.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events in the given collection.</summary>
   /// <param name="collection">The collection whose contained events should be retrieved.</param>
@@ -306,7 +306,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given place.</summary>
   /// <param name="place">The place whose events should be retrieved.</param>
@@ -319,7 +319,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IEvent>> BrowseEventsAsync(IPlace place, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "place", place.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("place", place.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the events associated with the given place.</summary>
   /// <param name="mbid">The MBID for the place whose events should be retrieved.</param>
@@ -344,6 +344,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<IEvent>> BrowsePlaceEventsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                              Include inc = Include.None,
                                                              CancellationToken cancellationToken = default)
-    => new BrowseEvents(this, Query.BuildExtraText(inc, "place", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseEvents(this, Query.CreateOptions("place", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Instruments.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Instruments.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IInstrument> BrowseAllInstruments(ICollection collection, int? pageSize = null, int? offset = null,
                                                                   Include inc = Include.None)
-    => new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseInstruments(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the instruments in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained instruments should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IInstrument> BrowseAllCollectionInstruments(Guid mbid, int? pageSize = null, int? offset = null,
                                                                             Include inc = Include.None)
-    => new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseInstruments(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the instruments in the given collection.</summary>
   /// <param name="collection">The collection whose contained instruments should be retrieved.</param>
@@ -71,7 +71,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IInstrument>> BrowseInstrumentsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
                                                                   CancellationToken cancellationToken = default) {
-    var browse = new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset);
+    var browse = new BrowseInstruments(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -99,6 +99,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<IInstrument>> BrowseCollectionInstrumentsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                             Include inc = Include.None,
                                                                             CancellationToken cancellationToken = default)
-    => new BrowseInstruments(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseInstruments(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Labels.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Labels.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllAreaLabels(Guid mbid, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "area", mbid), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("area", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the labels in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained labels should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllCollectionLabels(Guid mbid, int? pageSize = null, int? offset = null,
                                                                   Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the labels associated with the given area.</summary>
   /// <param name="area">The area whose labels should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllLabels(IArea area, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "area", area.Id), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("area", area.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the labels in the given collection.</summary>
   /// <param name="collection">The collection whose contained labels should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllLabels(ICollection collection, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the labels associated with the given release.</summary>
   /// <param name="release">The release whose labels should be retrieved.</param>
@@ -96,7 +96,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllLabels(IRelease release, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "release", release.Id), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("release", release.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the labels associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose labels should be retrieved.</param>
@@ -113,7 +113,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ILabel> BrowseAllReleaseLabels(Guid mbid, int? pageSize = null, int? offset = null,
                                                                Include inc = Include.None)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "release", mbid), pageSize, offset).AsStream();
+    => new BrowseLabels(this, Query.CreateOptions("release", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the labels associated with the given area.</summary>
   /// <param name="mbid">The MBID for the area whose labels should be retrieved.</param>
@@ -138,7 +138,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<ILabel>> BrowseAreaLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                             Include inc = Include.None,
                                                             CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("area", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained labels should be retrieved.</param>
@@ -163,7 +163,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<ILabel>> BrowseCollectionLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given area.</summary>
   /// <param name="area">The area whose labels should be retrieved.</param>
@@ -210,7 +210,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(IArea area, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("area", area.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels in the given collection.</summary>
   /// <param name="collection">The collection whose contained labels should be retrieved.</param>
@@ -223,7 +223,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given release.</summary>
   /// <param name="release">The release whose labels should be retrieved.</param>
@@ -236,7 +236,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ILabel>> BrowseLabelsAsync(IRelease release, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("release", release.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the labels associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose labels should be retrieved.</param>
@@ -261,6 +261,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<ILabel>> BrowseReleaseLabelsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                Include inc = Include.None,
                                                                CancellationToken cancellationToken = default)
-    => new BrowseLabels(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseLabels(this, Query.CreateOptions("release", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Places.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Places.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IPlace> BrowseAllAreaPlaces(Guid mbid, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", mbid), pageSize, offset).AsStream();
+    => new BrowsePlaces(this, Query.CreateOptions("area", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the places in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained places should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IPlace> BrowseAllCollectionPlaces(Guid mbid, int? pageSize = null, int? offset = null,
                                                                   Include inc = Include.None)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowsePlaces(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the places associated with the given area.</summary>
   /// <param name="area">The area whose places should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IPlace> BrowseAllPlaces(IArea area, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", area.Id), pageSize, offset).AsStream();
+    => new BrowsePlaces(this, Query.CreateOptions("area", area.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the places in the given collection.</summary>
   /// <param name="collection">The collection whose contained places should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IPlace> BrowseAllPlaces(ICollection collection, int? pageSize = null, int? offset = null,
                                                         Include inc = Include.None)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowsePlaces(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the places associated with the given area.</summary>
   /// <param name="mbid">The MBID for the area whose places should be retrieved.</param>
@@ -104,7 +104,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IPlace>> BrowseAreaPlacesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                             Include inc = Include.None,
                                                             CancellationToken cancellationToken = default)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowsePlaces(this, Query.CreateOptions("area", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained places should be retrieved.</param>
@@ -129,7 +129,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IPlace>> BrowseCollectionPlacesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                   Include inc = Include.None,
                                                                   CancellationToken cancellationToken = default)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowsePlaces(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places associated with the given area.</summary>
   /// <param name="area">The area whose places should be retrieved.</param>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IPlace>> BrowsePlacesAsync(IArea area, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "area", area.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowsePlaces(this, Query.CreateOptions("area", area.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the places in the given collection.</summary>
   /// <param name="collection">The collection whose contained places should be retrieved.</param>
@@ -178,6 +178,6 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IPlace>> BrowsePlacesAsync(ICollection collection, int? limit = null, int? offset = null,
                                                         Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowsePlaces(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowsePlaces(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Recordings.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Recordings.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllArtistRecordings(Guid mbid, int? pageSize = null, int? offset = null,
                                                                       Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", mbid), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("artist", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the recordings in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained recordings should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllCollectionRecordings(Guid mbid, int? pageSize = null, int? offset = null,
                                                                           Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the recordings associated with the given artist.</summary>
   /// <param name="artist">The artist whose recordings should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllRecordings(IArtist artist, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", artist.Id), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("artist", artist.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the recordings in the given collection.</summary>
   /// <param name="collection">The collection whose contained recordings should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllRecordings(ICollection collection, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the recordings associated with the given release.</summary>
   /// <param name="release">The release whose recordings should be retrieved.</param>
@@ -96,7 +96,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllRecordings(IRelease release, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", release.Id), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("release", release.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the recordings associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose recordings should be retrieved.</param>
@@ -113,7 +113,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IRecording> BrowseAllReleaseRecordings(Guid mbid, int? pageSize = null, int? offset = null,
                                                                        Include inc = Include.None)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", mbid), pageSize, offset).AsStream();
+    => new BrowseRecordings(this, Query.CreateOptions("release", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the recordings associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose recordings should be retrieved.</param>
@@ -139,7 +139,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseArtistRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None,
                                                                       CancellationToken cancellationToken = default)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseRecordings(this, Query.CreateOptions("artist", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained recordings should be retrieved.</param>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseCollectionRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                           Include inc = Include.None,
                                                                           CancellationToken cancellationToken = default)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseRecordings(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings associated with the given artist.</summary>
   /// <param name="artist">The artist whose recordings should be retrieved.</param>
@@ -215,7 +215,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
                                                                 CancellationToken cancellationToken = default)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseRecordings(this, Query.CreateOptions("artist", artist.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings in the given collection.</summary>
   /// <param name="collection">The collection whose contained recordings should be retrieved.</param>
@@ -229,7 +229,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
                                                                 CancellationToken cancellationToken = default) {
-    var browse = new BrowseRecordings(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset);
+    var browse = new BrowseRecordings(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -245,7 +245,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseRecordingsAsync(IRelease release, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
                                                                 CancellationToken cancellationToken = default)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", release.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseRecordings(this, Query.CreateOptions("release", release.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the recordings associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose recordings should be retrieved.</param>
@@ -271,6 +271,6 @@ public sealed partial class Query {
   public Task<IBrowseResults<IRecording>> BrowseReleaseRecordingsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                        Include inc = Include.None,
                                                                        CancellationToken cancellationToken = default)
-    => new BrowseRecordings(this, Query.BuildExtraText(inc, "release", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseRecordings(this, Query.CreateOptions("release", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.ReleaseGroups.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.ReleaseGroups.cs
@@ -29,7 +29,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IReleaseGroup> BrowseAllArtistReleaseGroups(Guid mbid, int? pageSize = null, int? offset = null,
                                                                             Include inc = Include.None, ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", mbid, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("artist", mbid, inc, type), pageSize, offset).AsStream();
 
   /// <summary>Returns the release groups in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained release groups should be retrieved.</param>
@@ -48,7 +48,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IReleaseGroup> BrowseAllCollectionReleaseGroups(Guid mbid, int? pageSize = null, int? offset = null,
                                                                                 Include inc = Include.None,
                                                                                 ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", mbid, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("collection", mbid, inc, type), pageSize, offset).AsStream();
 
   /// <summary>Returns the release groups associated with the given release.</summary>
   /// <param name="mbid">The MBID for the release whose release groups should be retrieved.</param>
@@ -70,7 +70,7 @@ public sealed partial class Query {
   /// </remarks>
   public IStreamingQueryResults<IReleaseGroup> BrowseAllReleaseReleaseGroups(Guid mbid, int? pageSize = null, int? offset = null,
                                                                              Include inc = Include.None, ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", mbid, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("release", mbid, inc, type), pageSize, offset).AsStream();
 
   /// <summary>Returns the release groups associated with the given artist.</summary>
   /// <param name="artist">The artist whose release groups should be retrieved.</param>
@@ -88,7 +88,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IReleaseGroup> BrowseAllReleaseGroups(IArtist artist, int? pageSize = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", artist.Id, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("artist", artist.Id, inc, type), pageSize, offset).AsStream();
 
   /// <summary>Returns the release groups in the given collection.</summary>
   /// <param name="collection">The collection whose contained release groups should be retrieved.</param>
@@ -107,7 +107,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IReleaseGroup> BrowseAllReleaseGroups(ICollection collection, int? pageSize = null,
                                                                       int? offset = null, Include inc = Include.None,
                                                                       ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", collection.Id, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("collection", collection.Id, inc, type), pageSize, offset).AsStream();
 
   /// <summary>Returns the release groups associated with the given release.</summary>
   /// <param name="release">The release whose release groups should be retrieved.</param>
@@ -128,7 +128,7 @@ public sealed partial class Query {
   /// </remarks>
   public IStreamingQueryResults<IReleaseGroup> BrowseAllReleaseGroups(IRelease release, int? pageSize = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", release.Id, type), pageSize, offset).AsStream();
+    => new BrowseReleaseGroups(this, Query.CreateOptions("release", release.Id, inc, type), pageSize, offset).AsStream();
 
   /// <inheritdoc cref="BrowseArtistReleaseGroupsAsync"/>
   public IBrowseResults<IReleaseGroup> BrowseArtistReleaseGroups(Guid mbid, int? limit = null, int? offset = null,
@@ -148,7 +148,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseArtistReleaseGroupsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                             Include inc = Include.None, ReleaseType? type = null,
                                                                             CancellationToken cancellationToken = default)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", mbid, type), limit, offset).NextAsync(cancellationToken);
+    => new BrowseReleaseGroups(this, Query.CreateOptions("artist", mbid, inc, type), limit, offset).NextAsync(cancellationToken);
 
   /// <inheritdoc cref="BrowseCollectionReleaseGroupsAsync"/>
   public IBrowseResults<IReleaseGroup> BrowseCollectionReleaseGroups(Guid mbid, int? limit = null, int? offset = null,
@@ -169,7 +169,7 @@ public sealed partial class Query {
                                                                                 Include inc = Include.None,
                                                                                 ReleaseType? type = null,
                                                                                 CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", mbid, type), limit, offset);
+    var browse = new BrowseReleaseGroups(this, Query.CreateOptions("collection", mbid, inc, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -195,7 +195,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseReleaseGroupsAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                              Include inc = Include.None, ReleaseType? type = null,
                                                                              CancellationToken cancellationToken = default)
-    => new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", mbid, type), limit, offset).NextAsync(cancellationToken);
+    => new BrowseReleaseGroups(this, Query.CreateOptions("release", mbid, inc, type), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the release groups associated with the given artist.</summary>
   /// <param name="artist">The artist whose release groups should be retrieved.</param>
@@ -252,7 +252,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(IArtist artist, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "artist", artist.Id, type), limit, offset);
+    var browse = new BrowseReleaseGroups(this, Query.CreateOptions("artist", artist.Id, inc, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -269,7 +269,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(ICollection collection, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "collection", collection.Id, type), limit, offset);
+    var browse = new BrowseReleaseGroups(this, Query.CreateOptions("collection", collection.Id, inc, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -289,7 +289,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IReleaseGroup>> BrowseReleaseGroupsAsync(IRelease release, int? limit = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleaseGroups(this, Query.BuildExtraText(inc, "release", release.Id, type), limit, offset);
+    var browse = new BrowseReleaseGroups(this, Query.CreateOptions("release", release.Id, inc, type), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 

--- a/MetaBrainz.MusicBrainz/Query.Browse.Releases.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Releases.cs
@@ -31,7 +31,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllAreaReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None, ReleaseType? type = null,
                                                                 ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "area", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("area", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose releases should be retrieved.</param>
@@ -51,7 +51,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllArtistReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                   Include inc = Include.None, ReleaseType? type = null,
                                                                   ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "artist", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("artist", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained releases should be retrieved.</param>
@@ -71,7 +71,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllCollectionReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "collection", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("collection", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given label.</summary>
   /// <param name="mbid">The MBID for the label whose releases should be retrieved.</param>
@@ -91,7 +91,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllLabelReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "label", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("label", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose releases should be retrieved.</param>
@@ -111,7 +111,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllRecordingReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                      Include inc = Include.None, ReleaseType? type = null,
                                                                      ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "recording", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("recording", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given release group.</summary>
   /// <param name="mbid">The MBID for the release group whose releases should be retrieved.</param>
@@ -131,7 +131,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleaseGroupReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                         Include inc = Include.None, ReleaseType? type = null,
                                                                         ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("release-group", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given area.</summary>
   /// <param name="area">The area whose releases should be retrieved.</param>
@@ -151,7 +151,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(IArea area, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "area", area.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("area", area.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given artist.</summary>
   /// <param name="artist">The artist whose releases should be retrieved.</param>
@@ -171,7 +171,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(IArtist artist, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "artist", artist.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("artist", artist.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases in the given collection.</summary>
   /// <param name="collection">The collection whose contained releases should be retrieved.</param>
@@ -191,7 +191,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(ICollection collection, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "collection", collection.Id, type, status), pageSize, offset)
+    => new BrowseReleases(this, Query.CreateOptions("collection", collection.Id, inc, type, status), pageSize, offset)
       .AsStream();
 
   /// <summary>Returns the releases associated with the given label.</summary>
@@ -212,7 +212,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(ILabel label, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "label", label.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("label", label.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given recording.</summary>
   /// <param name="recording">The recording whose releases should be retrieved.</param>
@@ -232,7 +232,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(IRecording recording, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "recording", recording.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("recording", recording.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given release group.</summary>
   /// <param name="releaseGroup">The release group whose releases should be retrieved.</param>
@@ -252,7 +252,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(IReleaseGroup releaseGroup, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id, type, status), pageSize, offset)
+    => new BrowseReleases(this, Query.CreateOptions("release-group", releaseGroup.Id, inc, type, status), pageSize, offset)
       .AsStream();
 
   /// <summary>Returns the releases associated with the given track.</summary>
@@ -273,7 +273,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllReleases(ITrack track, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "track", track.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("track", track.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>
   /// Returns the releases that include the given artist in a track-level artist credit only.
@@ -295,7 +295,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllTrackArtistReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("track_artist", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>
   /// Returns the releases that include the given artist in a track-level artist credit only.
@@ -317,7 +317,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllTrackArtistReleases(IArtist artist, int? pageSize = null, int? offset = null,
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", artist.Id, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("track_artist", artist.Id, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns the releases associated with the given track.</summary>
   /// <param name="mbid">The MBID for the track whose releases should be retrieved.</param>
@@ -337,7 +337,7 @@ public sealed partial class Query {
   public IStreamingQueryResults<IRelease> BrowseAllTrackReleases(Guid mbid, int? pageSize = null, int? offset = null,
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "track", mbid, type, status), pageSize, offset).AsStream();
+    => new BrowseReleases(this, Query.CreateOptions("track", mbid, inc, type, status), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given area.</summary>
   /// <param name="mbid">The MBID for the area whose releases should be retrieved.</param>
@@ -368,7 +368,7 @@ public sealed partial class Query {
                                                                 Include inc = Include.None, ReleaseType? type = null,
                                                                 ReleaseStatus? status = null,
                                                                 CancellationToken cancellationToken = default)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "area", mbid, type, status), limit, offset).NextAsync(cancellationToken);
+    => new BrowseReleases(this, Query.CreateOptions("area", mbid, inc, type, status), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose releases should be retrieved.</param>
@@ -399,7 +399,7 @@ public sealed partial class Query {
                                                                   Include inc = Include.None, ReleaseType? type = null,
                                                                   ReleaseStatus? status = null,
                                                                   CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "artist", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("artist", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -433,7 +433,7 @@ public sealed partial class Query {
                                                                       Include inc = Include.None, ReleaseType? type = null,
                                                                       ReleaseStatus? status = null,
                                                                       CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "collection", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("collection", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -466,7 +466,7 @@ public sealed partial class Query {
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null,
                                                                  CancellationToken cancellationToken = default)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "label", mbid, type, status), limit, offset).NextAsync(cancellationToken);
+    => new BrowseReleases(this, Query.CreateOptions("label", mbid, inc, type, status), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the releases associated with the given recording.</summary>
   /// <param name="mbid">The MBID for the recording whose releases should be retrieved.</param>
@@ -498,7 +498,7 @@ public sealed partial class Query {
                                                                      Include inc = Include.None, ReleaseType? type = null,
                                                                      ReleaseStatus? status = null,
                                                                      CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "recording", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("recording", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -532,7 +532,7 @@ public sealed partial class Query {
                                                                         Include inc = Include.None, ReleaseType? type = null,
                                                                         ReleaseStatus? status = null,
                                                                         CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("release-group", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -618,7 +618,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IBrowseResults<IRelease> BrowseReleases(IReleaseGroup releaseGroup, int? limit = null, int? offset = null,
                                                  Include inc = Include.None, ReleaseType? type = null, ReleaseStatus? status = null)
-    => new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id, type, status), limit, offset)
+    => new BrowseReleases(this, Query.CreateOptions("release-group", releaseGroup.Id, inc, type, status), limit, offset)
       .Next();
 
   /// <summary>Returns (the specified subset of) the releases associated with the given track.</summary>
@@ -650,7 +650,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "area", area.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("area", area.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -669,7 +669,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "artist", artist.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("artist", artist.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -688,7 +688,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "collection", collection.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("collection", collection.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -707,7 +707,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "label", label.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("label", label.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -726,7 +726,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "recording", recording.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("recording", recording.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -745,7 +745,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "release-group", releaseGroup.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("release-group", releaseGroup.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -764,7 +764,7 @@ public sealed partial class Query {
                                                             Include inc = Include.None, ReleaseType? type = null,
                                                             ReleaseStatus? status = null,
                                                             CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track", track.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("track", track.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -819,7 +819,7 @@ public sealed partial class Query {
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null,
                                                                        CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("track_artist", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -840,7 +840,7 @@ public sealed partial class Query {
                                                                        Include inc = Include.None, ReleaseType? type = null,
                                                                        ReleaseStatus? status = null,
                                                                        CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track_artist", artist.Id, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("track_artist", artist.Id, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 
@@ -873,7 +873,7 @@ public sealed partial class Query {
                                                                  Include inc = Include.None, ReleaseType? type = null,
                                                                  ReleaseStatus? status = null,
                                                                  CancellationToken cancellationToken = default) {
-    var browse = new BrowseReleases(this, Query.BuildExtraText(inc, "track", mbid, type, status), limit, offset);
+    var browse = new BrowseReleases(this, Query.CreateOptions("track", mbid, inc, type, status), limit, offset);
     return browse.NextAsync(cancellationToken);
   }
 

--- a/MetaBrainz.MusicBrainz/Query.Browse.Series.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Series.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ISeries> BrowseAllCollectionSeries(Guid mbid, int? pageSize = null, int? offset = null,
                                                                    Include inc = Include.None)
-    => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseSeries(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the series in the given collection.</summary>
   /// <param name="collection">The collection whose contained series should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<ISeries> BrowseAllSeries(ICollection collection, int? pageSize = null, int? offset = null,
                                                          Include inc = Include.None)
-    => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseSeries(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the series in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained series should be retrieved.</param>
@@ -71,7 +71,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<ISeries>> BrowseCollectionSeriesAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                    Include inc = Include.None,
                                                                    CancellationToken cancellationToken = default)
-    => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseSeries(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the series in the given collection.</summary>
   /// <param name="collection">The collection whose contained series should be retrieved.</param>
@@ -96,6 +96,6 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<ISeries>> BrowseSeriesAsync(ICollection collection, int? limit = null, int? offset = null,
                                                          Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseSeries(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseSeries(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Browse.Works.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Works.cs
@@ -28,7 +28,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IWork> BrowseAllArtistWorks(Guid mbid, int? pageSize = null, int? offset = null,
                                                             Include inc = Include.None)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", mbid), pageSize, offset).AsStream();
+    => new BrowseWorks(this, Query.CreateOptions("artist", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the works in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained works should be retrieved.</param>
@@ -45,7 +45,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IWork> BrowseAllCollectionWorks(Guid mbid, int? pageSize = null, int? offset = null,
                                                                 Include inc = Include.None)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", mbid), pageSize, offset).AsStream();
+    => new BrowseWorks(this, Query.CreateOptions("collection", mbid, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the works associated with the given artist.</summary>
   /// <param name="artist">The artist whose works should be retrieved.</param>
@@ -62,7 +62,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IWork> BrowseAllWorks(IArtist artist, int? pageSize = null, int? offset = null,
                                                       Include inc = Include.None)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", artist.Id), pageSize, offset).AsStream();
+    => new BrowseWorks(this, Query.CreateOptions("artist", artist.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns the works in the given collection.</summary>
   /// <param name="collection">The collection whose contained works should be retrieved.</param>
@@ -79,7 +79,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public IStreamingQueryResults<IWork> BrowseAllWorks(ICollection collection, int? pageSize = null, int? offset = null,
                                                       Include inc = Include.None)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", collection.Id), pageSize, offset).AsStream();
+    => new BrowseWorks(this, Query.CreateOptions("collection", collection.Id, inc), pageSize, offset).AsStream();
 
   /// <summary>Returns (the specified subset of) the works associated with the given artist.</summary>
   /// <param name="mbid">The MBID for the artist whose works should be retrieved.</param>
@@ -104,7 +104,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IWork>> BrowseArtistWorksAsync(Guid mbid, int? limit = null, int? offset = null,
                                                             Include inc = Include.None,
                                                             CancellationToken cancellationToken = default)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseWorks(this, Query.CreateOptions("artist", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works in the given collection.</summary>
   /// <param name="mbid">The MBID for the collection whose contained works should be retrieved.</param>
@@ -129,7 +129,7 @@ public sealed partial class Query {
   public Task<IBrowseResults<IWork>> BrowseCollectionWorksAsync(Guid mbid, int? limit = null, int? offset = null,
                                                                 Include inc = Include.None,
                                                                 CancellationToken cancellationToken = default)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", mbid), limit, offset).NextAsync(cancellationToken);
+    => new BrowseWorks(this, Query.CreateOptions("collection", mbid, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works associated with the given artist.</summary>
   /// <param name="artist">The artist whose works should be retrieved.</param>
@@ -165,7 +165,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IWork>> BrowseWorksAsync(IArtist artist, int? limit = null, int? offset = null,
                                                       Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "artist", artist.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseWorks(this, Query.CreateOptions("artist", artist.Id, inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Returns (the specified subset of) the works in the given collection.</summary>
   /// <param name="collection">The collection whose contained works should be retrieved.</param>
@@ -178,6 +178,6 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public Task<IBrowseResults<IWork>> BrowseWorksAsync(ICollection collection, int? limit = null, int? offset = null,
                                                       Include inc = Include.None, CancellationToken cancellationToken = default)
-    => new BrowseWorks(this, Query.BuildExtraText(inc, "collection", collection.Id), limit, offset).NextAsync(cancellationToken);
+    => new BrowseWorks(this, Query.CreateOptions("collection", collection.Id, inc), limit, offset).NextAsync(cancellationToken);
 
 }

--- a/MetaBrainz.MusicBrainz/Query.Lookup.cs
+++ b/MetaBrainz.MusicBrainz/Query.Lookup.cs
@@ -31,7 +31,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IArea> LookupAreaAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Area>("area", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Area>("area", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified artist.</summary>
   /// <param name="mbid">The MBID for the artist to look up.</param>
@@ -65,7 +65,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IArtist> LookupArtistAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
                                                ReleaseStatus? status = null, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Artist>("artist", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
+    => await this.PerformRequestAsync<Artist>("artist", mbid, Query.CreateOptions(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified collection.</summary>
@@ -86,7 +86,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<ICollection> LookupCollectionAsync(Guid mbid, Include inc = Include.None,
                                                        CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Collection>("collection", mbid, Query.BuildExtraText(inc), cancellationToken)
+    => await this.PerformRequestAsync<Collection>("collection", mbid, Query.CreateOptions(inc), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified disc ID.</summary>
@@ -135,7 +135,7 @@ public sealed partial class Query {
   public async Task<IDiscIdLookupResult> LookupDiscIdAsync(string discid, int[]? toc = null, Include inc = Include.None,
                                                            bool allMediaFormats = false, bool noStubs = false,
                                                            CancellationToken cancellationToken = default) {
-    var extra = Query.BuildExtraText(inc, toc, allMediaFormats, noStubs);
+    var extra = Query.CreateOptions(toc, inc, allMediaFormats, noStubs);
     return await this.PerformRequestAsync<DiscIdLookupResult>("discid", discid, extra, cancellationToken).ConfigureAwait(false);
   }
 
@@ -155,7 +155,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IEvent> LookupEventAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Event>("event", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Event>("event", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified genre.</summary>
   /// <param name="mbid">The MBID for the genre to look up.</param>
@@ -171,7 +171,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IGenre> LookupGenreAsync(Guid mbid, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Genre>("genre", mbid, string.Empty, cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Genre>("genre", mbid, null, cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified instrument.</summary>
   /// <param name="mbid">The MBID for the instrument to look up.</param>
@@ -191,7 +191,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IInstrument> LookupInstrumentAsync(Guid mbid, Include inc = Include.None,
                                                        CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Instrument>("instrument", mbid, Query.BuildExtraText(inc), cancellationToken)
+    => await this.PerformRequestAsync<Instrument>("instrument", mbid, Query.CreateOptions(inc), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the recordings associated with the specified ISRC value.</summary>
@@ -210,7 +210,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IIsrc> LookupIsrcAsync(string isrc, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Isrc>("isrc", isrc, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Isrc>("isrc", isrc, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the works associated with the specified ISWC.</summary>
   /// <param name="iswc">The ISWC to look up.</param>
@@ -231,7 +231,7 @@ public sealed partial class Query {
   public async Task<IReadOnlyList<IWork>> LookupIswcAsync(string iswc, Include inc = Include.None,
                                                           CancellationToken cancellationToken = default) {
     // This "lookup" behaves like a browse, except that it does not support offset/limit.
-    var lookup = new IswcLookup(this, iswc, Query.BuildExtraText(inc));
+    var lookup = new IswcLookup(this, iswc, Query.CreateOptions(inc));
     var results = await lookup.NextAsync(cancellationToken).ConfigureAwait(false);
     return results.Results;
   }
@@ -266,7 +266,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<ILabel> LookupLabelAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
                                              ReleaseStatus? status = null, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Label>("label", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
+    => await this.PerformRequestAsync<Label>("label", mbid, Query.CreateOptions(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified place.</summary>
@@ -285,7 +285,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IPlace> LookupPlaceAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Place>("place", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Place>("place", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified recording.</summary>
   /// <param name="mbid">The MBID for the recording to look up.</param>
@@ -317,7 +317,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IRecording> LookupRecordingAsync(Guid mbid, Include inc = Include.None, ReleaseType? type = null,
                                                      ReleaseStatus? status = null, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Recording>("recording", mbid, Query.BuildExtraText(inc, status, type), cancellationToken)
+    => await this.PerformRequestAsync<Recording>("recording", mbid, Query.CreateOptions(inc, status, type), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified release.</summary>
@@ -337,7 +337,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IRelease> LookupReleaseAsync(Guid mbid, Include inc = Include.None,
                                                  CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Release>("release", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Release>("release", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified release group.</summary>
   /// <param name="mbid">The MBID for the release group to look up.</param>
@@ -363,7 +363,7 @@ public sealed partial class Query {
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IReleaseGroup> LookupReleaseGroupAsync(Guid mbid, Include inc = Include.None, ReleaseStatus? status = null,
                                                            CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<ReleaseGroup>("release-group", mbid, Query.BuildExtraText(inc, status), cancellationToken)
+    => await this.PerformRequestAsync<ReleaseGroup>("release-group", mbid, Query.CreateOptions(inc, status), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified series.</summary>
@@ -382,7 +382,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<ISeries> LookupSeriesAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Series>("series", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Series>("series", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified URL.</summary>
   /// <param name="mbid">The MBID for the URL to look up.</param>
@@ -408,7 +408,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IUrl> LookupUrlAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Url>("url", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Url>("url", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified URL.</summary>
   /// <param name="resource">The resource to look up.</param>
@@ -418,7 +418,7 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IUrl> LookupUrlAsync(Uri resource, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Url>("url", null, Query.BuildExtraText(inc, resource), cancellationToken)
+    => await this.PerformRequestAsync<Url>("url", null, Query.CreateOptions(inc, resource), cancellationToken)
                  .ConfigureAwait(false);
 
   /// <summary>Looks up the specified work.</summary>
@@ -437,6 +437,6 @@ public sealed partial class Query {
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
   public async Task<IWork> LookupWorkAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Work>("work", mbid, Query.BuildExtraText(inc), cancellationToken).ConfigureAwait(false);
+    => await this.PerformRequestAsync<Work>("work", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
 }

--- a/MetaBrainz.MusicBrainz/ReleaseStatus.cs
+++ b/MetaBrainz.MusicBrainz/ReleaseStatus.cs
@@ -24,7 +24,7 @@ public enum ReleaseStatus : byte {
   /// A give-away release or a release intended to promote an upcoming official release (e.g. pre-release versions, releases
   /// included with a magazine, versions supplied to radio DJs for air-play).
   /// </summary>
-  Promotional = 1 << 2,
+  Promotion = 1 << 2,
 
   /// <summary>
   /// An alternate version of a release where the titles have been changed. These don't correspond to any real release and should be
@@ -32,9 +32,23 @@ public enum ReleaseStatus : byte {
   /// </summary>
   PseudoRelease = 1 << 3,
 
-  // The MusicBrainz documentation pages call the status "Promotional", which matches "Official".
-  // However, the release editor (and web service) use "Promotion").
-  /// <inheritdoc cref="Promotional"/>
-  Promotion = ReleaseStatus.Promotional,
+  /// <summary>
+  /// A previously official release that was actively withdrawn from circulation by the artist and/or their record company after
+  /// being released, whether to replace it with a new version with some changes or to just retire it altogether (e.g. because of
+  /// legal issues).
+  /// </summary>
+  Withdrawn = 1 << 4,
+
+  /// <summary>
+  /// A planned official release that was cancelled before being released, but for which enough info is known to still confidently
+  /// list it (e.g. it was available for preorder).
+  /// </summary>
+  Cancelled = 1 << 5,
+
+  // The MusicBrainz documentation pages used to call the status "Promotional", which matches "Official", but the release editor
+  // (and web service) used "Promotion". This has since been fixed, making "Promotional" obsolete.
+  /// <inheritdoc cref="Promotion"/>
+  [Obsolete($"Use {nameof(ReleaseStatus.Promotion)} instead.")]
+  Promotional = ReleaseStatus.Promotion,
 
 }

--- a/MetaBrainz.MusicBrainz/ReleaseType.cs
+++ b/MetaBrainz.MusicBrainz/ReleaseType.cs
@@ -69,6 +69,12 @@ public enum ReleaseType {
 
   #region Secondary Types
 
+  /// <summary>
+  /// An audio drama is an audio-only performance of a play (often, but not always, meant for radio). Unlike audiobooks, it usually
+  /// has multiple performers rather than a main narrator.
+  /// </summary>
+  AudioDrama = 1 << 19,
+
   /// <summary>An audiobook is a book read by a narrator without music.</summary>
   Audiobook = 1 << 10,
 
@@ -104,6 +110,15 @@ public enum ReleaseType {
   /// </summary>
   DJMix = 1 << 12,
 
+  /// <summary>
+  /// A demo is typically distributed for limited circulation or reference use, rather than for general public release. It is a way
+  /// for artists to pass along their music to record labels, producers, DJs or other artists.
+  /// </summary>
+  Demo = 1 << 20,
+
+  /// <summary>A release mostly consisting of field recordings (such as nature sounds or city/industrial noise).</summary>
+  FieldRecording = 1 << 21,
+
   /// <summary>An interview release contains an interview, generally with an artist.</summary>
   Interview = 1 << 13,
 
@@ -133,6 +148,10 @@ public enum ReleaseType {
 
   /// <summary>Non-music spoken word releases.</summary>
   SpokenWord = 1 << 18,
+
+  #endregion
+
+  #region Aliases
 
   /// <inheritdoc cref="MixTape"/>
   StreetAlbum = ReleaseType.MixTape,

--- a/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
@@ -79,6 +79,7 @@ public enum Include : long {
   RecordingLevelRelationships = 70368744177664L,
   RecordingRelationships = 140737488355328L,
   Recordings = 8L,
+  ReleaseGroupLevelRelationships = 18014398509481984L,
   ReleaseGroupRelationships = 281474976710656L,
   ReleaseGroups = 16L,
   ReleaseRelationships = 562949953421312L,
@@ -1749,10 +1750,13 @@ public sealed class Query : System.IDisposable {
 public enum ReleaseStatus : byte {
 
   Bootleg = (byte) 1,
+  Cancelled = (byte) 32,
   Official = (byte) 2,
   Promotion = (byte) 4,
+  [System.ObsoleteAttribute("Use Promotion instead.")]
   Promotional = (byte) 4,
   PseudoRelease = (byte) 8,
+  Withdrawn = (byte) 16,
 
 }
 ```
@@ -1765,10 +1769,13 @@ public enum ReleaseType {
 
   Album = 1,
   Audiobook = 1024,
+  AudioDrama = 524288,
   Broadcast = 2,
   Compilation = 2048,
+  Demo = 1048576,
   DJMix = 4096,
   EP = 4,
+  FieldRecording = 2097152,
   Interview = 8192,
   Live = 16384,
   MixTape = 32768,

--- a/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
@@ -79,6 +79,7 @@ public enum Include : long {
   RecordingLevelRelationships = 70368744177664L,
   RecordingRelationships = 140737488355328L,
   Recordings = 8L,
+  ReleaseGroupLevelRelationships = 18014398509481984L,
   ReleaseGroupRelationships = 281474976710656L,
   ReleaseGroups = 16L,
   ReleaseRelationships = 562949953421312L,
@@ -1749,10 +1750,13 @@ public sealed class Query : System.IDisposable {
 public enum ReleaseStatus : byte {
 
   Bootleg = (byte) 1,
+  Cancelled = (byte) 32,
   Official = (byte) 2,
   Promotion = (byte) 4,
+  [System.ObsoleteAttribute("Use Promotion instead.")]
   Promotional = (byte) 4,
   PseudoRelease = (byte) 8,
+  Withdrawn = (byte) 16,
 
 }
 ```
@@ -1765,10 +1769,13 @@ public enum ReleaseType {
 
   Album = 1,
   Audiobook = 1024,
+  AudioDrama = 524288,
   Broadcast = 2,
   Compilation = 2048,
+  Demo = 1048576,
   DJMix = 4096,
   EP = 4,
+  FieldRecording = 2097152,
   Interview = 8192,
   Live = 16384,
   MixTape = 32768,


### PR DESCRIPTION
Instead of string, it now works using a dictionary.

All non-submission requests now explicitly specify `fmt=json`. This may fix #64.

The `Include`, `ReleaseStatus` and `ReleaseType` enums have had values added to them (with `ReleaseStatus.Promotional` marked as `[Obsolete]`). Fixes #66.

This also bumps the version to 6.1.0-pre due to new API.