### PR TITLE
Add `genre/all` endpoint

### DIFF
--- a/MetaBrainz.MusicBrainz/Json/Readers/BrowseResultReader.cs
+++ b/MetaBrainz.MusicBrainz/Json/Readers/BrowseResultReader.cs
@@ -19,6 +19,7 @@ internal sealed class BrowseResultReader : ObjectReader<BrowseResult> {
     IReadOnlyList<ICollection>? collections = null;
     int? count = null;
     IReadOnlyList<IEvent>? events = null;
+    IReadOnlyList<IGenre>? genres = null;
     IReadOnlyList<IInstrument>? instruments = null;
     IReadOnlyList<ILabel>? labels = null;
     int? offset = null;
@@ -38,6 +39,7 @@ internal sealed class BrowseResultReader : ObjectReader<BrowseResult> {
           case "artist-count":
           case "collection-count":
           case "event-count":
+          case "genre-count":
           case "instrument-count":
           case "label-count":
           case "place-count":
@@ -52,6 +54,7 @@ internal sealed class BrowseResultReader : ObjectReader<BrowseResult> {
           case "artist-offset":
           case "collection-offset":
           case "event-offset":
+          case "genre-offset":
           case "instrument-offset":
           case "label-offset":
           case "place-offset":
@@ -73,6 +76,9 @@ internal sealed class BrowseResultReader : ObjectReader<BrowseResult> {
             break;
           case "events":
             events = reader.ReadList(EventReader.Instance, options);
+            break;
+          case "genres":
+            genres = reader.ReadList(GenreReader.Instance, options);
             break;
           case "instruments":
             instruments = reader.ReadList(InstrumentReader.Instance, options);
@@ -120,6 +126,7 @@ internal sealed class BrowseResultReader : ObjectReader<BrowseResult> {
       Artists = artists,
       Collections = collections,
       Events = events,
+      Genres = genres,
       Instruments = instruments,
       Labels = labels,
       Places = places,

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseGenres.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseGenres.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
+
+namespace MetaBrainz.MusicBrainz.Objects.Browses;
+
+internal sealed class BrowseGenres : BrowseResults<IGenre> {
+
+  public BrowseGenres(Query query, int? limit, int? offset) : base(query, "genre", "all", null, limit, offset) {
+  }
+
+  public override IReadOnlyList<IGenre> Results => this.CurrentResult?.Genres ?? Array.Empty<IGenre>();
+
+}

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseResult.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseResult.cs
@@ -22,6 +22,8 @@ internal sealed class BrowseResult : JsonBasedObject {
 
   public IReadOnlyList<IEvent>? Events;
 
+  public IReadOnlyList<IGenre>? Genres;
+
   public IReadOnlyList<IInstrument>? Instruments;
 
   public IReadOnlyList<ILabel>? Labels;

--- a/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
@@ -1,0 +1,27 @@
+﻿using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MetaBrainz.Common;
+
+namespace MetaBrainz.MusicBrainz;
+
+public sealed partial class Query {
+
+  /// <summary>Gets the names of all genres known to MusicBrainz.</summary>
+  /// <returns>All genre names, in alphabetical order.</returns>
+  /// <exception cref="HttpError">When the web service reports an error.</exception>
+  /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
+  public string[] GetAllGenreNames() => AsyncUtils.ResultOf(this.GetAllGenreNamesAsync());
+
+  /// <summary>Gets the names of all genres known to MusicBrainz.</summary>
+  /// <returns>All genre names, in alphabetical order.</returns>
+  /// <exception cref="HttpError">When the web service reports an error.</exception>
+  /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
+  public async Task<string[]> GetAllGenreNamesAsync(CancellationToken cancellationToken = default) {
+    var result = await this.PerformRequestAsync("genre", "all", null, cancellationToken, "txt");
+    var text = await result.GetStringContentAsync(cancellationToken);
+    return text.Split('\n');
+  }
+
+}

--- a/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
@@ -3,10 +3,29 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using MetaBrainz.Common;
+using MetaBrainz.MusicBrainz.Interfaces.Browses;
+using MetaBrainz.MusicBrainz.Interfaces.Entities;
+using MetaBrainz.MusicBrainz.Objects.Browses;
 
 namespace MetaBrainz.MusicBrainz;
 
 public sealed partial class Query {
+
+  /// <summary>Returns (the specified subset of) the genres known to MusicBrainz.</summary>
+  /// <param name="limit">The maximum number of results to return (1-100; default is 25).</param>
+  /// <param name="offset">The offset at which to start (i.e. the number of results to skip).</param>
+  /// <returns>The browse request, including the initial results.</returns>
+  public IBrowseResults<IGenre> BrowseAllGenres(int? limit = null, int? offset = null)
+    => AsyncUtils.ResultOf(this.BrowseAllGenresAsync(limit, offset));
+
+  /// <summary>Returns (the specified subset of) the genres known to MusicBrainz.</summary>
+  /// <param name="limit">The maximum number of results to return (1-100; default is 25).</param>
+  /// <param name="offset">The offset at which to start (i.e. the number of results to skip).</param>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
+  /// <returns>The browse request, including the initial results.</returns>
+  public Task<IBrowseResults<IGenre>> BrowseAllGenresAsync(int? limit = null, int? offset = null,
+                                                           CancellationToken cancellationToken = default)
+    => new BrowseGenres(this, limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Gets the names of all genres known to MusicBrainz.</summary>
   /// <returns>All genre names, in alphabetical order.</returns>
@@ -15,6 +34,7 @@ public sealed partial class Query {
   public string[] GetAllGenreNames() => AsyncUtils.ResultOf(this.GetAllGenreNamesAsync());
 
   /// <summary>Gets the names of all genres known to MusicBrainz.</summary>
+  /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>All genre names, in alphabetical order.</returns>
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>

--- a/MetaBrainz.MusicBrainz/Query.Internals.cs
+++ b/MetaBrainz.MusicBrainz/Query.Internals.cs
@@ -269,9 +269,7 @@ public sealed partial class Query : IDisposable {
   }
 
   private static Dictionary<string, string> CreateOptions(Include inc, Uri resource) {
-    var options = new Dictionary<string, string> {
-      ["resource"] = Uri.EscapeDataString(resource.ToString())
-    };
+    var options = new Dictionary<string, string> { ["resource"] = Uri.EscapeDataString(resource.ToString()) };
     Query.AddIncludeText(options, inc);
     return options;
   }
@@ -287,9 +285,7 @@ public sealed partial class Query : IDisposable {
 
   private static Dictionary<string, string> CreateOptions(string field, Guid id, Include inc, ReleaseType? type = null,
                                                           ReleaseStatus? status = null) {
-    var options = new Dictionary<string, string> {
-      [field] = id.ToString("D")
-    };
+    var options = new Dictionary<string, string> { [field] = id.ToString("D") };
     Query.AddIncludeText(options, inc);
     Query.AddReleaseFilter(options, type, status);
     return options;
@@ -340,7 +336,9 @@ public sealed partial class Query : IDisposable {
 
   #region HttpClient / IDisposable
 
-  private static readonly MediaTypeWithQualityHeaderValue AcceptHeader = new("application/json");
+  private static readonly MediaTypeWithQualityHeaderValue AcceptHeaderForJson = new("application/json");
+
+  private static readonly MediaTypeWithQualityHeaderValue AcceptHeaderForText = new("text/plain");
 
   private static readonly ProductInfoHeaderValue LibraryComment = new($"({Query.UserAgentUrl})");
 
@@ -477,14 +475,21 @@ public sealed partial class Query : IDisposable {
   }
 
   private async Task<HttpResponseMessage> PerformRequestAsync(Uri uri, HttpMethod method, HttpContent? body,
-                                                              CancellationToken cancellationToken) {
+                                                              CancellationToken cancellationToken, string? format = null) {
     using var request = new HttpRequestMessage(method, uri);
     var ts = Query.TraceSource;
     ts.TraceEvent(TraceEventType.Verbose, 1, "WEB SERVICE REQUEST: {0} {1}", method.Method, request.RequestUri);
     var client = this.Client;
     {
       var headers = request.Headers;
-      headers.Accept.Add(Query.AcceptHeader);
+      switch (format) {
+        case "json":
+          headers.Accept.Add(Query.AcceptHeaderForJson);
+          break;
+        case "txt":
+          headers.Accept.Add(Query.AcceptHeaderForText);
+          break;
+      }
       if (this.BearerToken is not null) {
         headers.Authorization = new AuthenticationHeaderValue("Bearer", this.BearerToken);
       }
@@ -561,9 +566,9 @@ public sealed partial class Query : IDisposable {
     => this.PerformRequestAsync(entity, id.ToString("D"), options, cancellationToken);
 
   internal Task<HttpResponseMessage> PerformRequestAsync(string entity, string? id, IReadOnlyDictionary<string, string>? options,
-                                                         CancellationToken cancellationToken) {
-    var uri = this.BuildUri($"{entity}/{id}", options, "json");
-    return Query.ApplyDelayAsync(token => this.PerformRequestAsync(uri, HttpMethod.Get, null, token), cancellationToken);
+                                                         CancellationToken cancellationToken, string? format = "json") {
+    var uri = this.BuildUri($"{entity}/{id}", options, format);
+    return Query.ApplyDelayAsync(token => this.PerformRequestAsync(uri, HttpMethod.Get, null, token, format), cancellationToken);
   }
 
   internal Task<T> PerformRequestAsync<T>(string entity, Guid id, IReadOnlyDictionary<string, string>? options,

--- a/MetaBrainz.MusicBrainz/Query.Internals.cs
+++ b/MetaBrainz.MusicBrainz/Query.Internals.cs
@@ -475,7 +475,7 @@ public sealed partial class Query : IDisposable {
   }
 
   private async Task<HttpResponseMessage> PerformRequestAsync(Uri uri, HttpMethod method, HttpContent? body,
-                                                              CancellationToken cancellationToken, string? format = null) {
+                                                              CancellationToken cancellationToken, string? format = "json") {
     using var request = new HttpRequestMessage(method, uri);
     var ts = Query.TraceSource;
     ts.TraceEvent(TraceEventType.Verbose, 1, "WEB SERVICE REQUEST: {0} {1}", method.Method, request.RequestUri);

--- a/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
@@ -1324,6 +1324,10 @@ public sealed class Query : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Searches.ISearchResults<MetaBrainz.MusicBrainz.Interfaces.Searches.ISearchResult<MetaBrainz.MusicBrainz.Interfaces.Entities.IWork>>> FindWorksAsync(string query, int? limit = default, int? offset = default, bool simple = false, System.Threading.CancellationToken cancellationToken = default);
 
+  public string[] GetAllGenreNames();
+
+  public System.Threading.Tasks.Task<string[]> GetAllGenreNamesAsync(System.Threading.CancellationToken cancellationToken = default);
+
   public MetaBrainz.MusicBrainz.Interfaces.Entities.IArea LookupArea(System.Guid mbid, Include inc = Include.None);
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IArea> LookupAreaAsync(System.Guid mbid, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);

--- a/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net6.0.cs.md
@@ -772,6 +772,10 @@ public sealed class Query : System.IDisposable {
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IEvent> BrowseAllEvents(MetaBrainz.MusicBrainz.Interfaces.Entities.IPlace place, int? pageSize = default, int? offset = default, Include inc = Include.None);
 
+  public MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre> BrowseAllGenres(int? limit = default, int? offset = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre>> BrowseAllGenresAsync(int? limit = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.ICollection> BrowseAllInstrumentCollections(System.Guid mbid, int? pageSize = default, int? offset = default);
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IInstrument> BrowseAllInstruments(MetaBrainz.MusicBrainz.Interfaces.Entities.ICollection collection, int? pageSize = default, int? offset = default, Include inc = Include.None);

--- a/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
@@ -1324,6 +1324,10 @@ public sealed class Query : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Searches.ISearchResults<MetaBrainz.MusicBrainz.Interfaces.Searches.ISearchResult<MetaBrainz.MusicBrainz.Interfaces.Entities.IWork>>> FindWorksAsync(string query, int? limit = default, int? offset = default, bool simple = false, System.Threading.CancellationToken cancellationToken = default);
 
+  public string[] GetAllGenreNames();
+
+  public System.Threading.Tasks.Task<string[]> GetAllGenreNamesAsync(System.Threading.CancellationToken cancellationToken = default);
+
   public MetaBrainz.MusicBrainz.Interfaces.Entities.IArea LookupArea(System.Guid mbid, Include inc = Include.None);
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IArea> LookupAreaAsync(System.Guid mbid, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);

--- a/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
@@ -772,6 +772,10 @@ public sealed class Query : System.IDisposable {
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IEvent> BrowseAllEvents(MetaBrainz.MusicBrainz.Interfaces.Entities.IPlace place, int? pageSize = default, int? offset = default, Include inc = Include.None);
 
+  public MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre> BrowseAllGenres(int? limit = default, int? offset = default);
+
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre>> BrowseAllGenresAsync(int? limit = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.ICollection> BrowseAllInstrumentCollections(System.Guid mbid, int? pageSize = default, int? offset = default);
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IInstrument> BrowseAllInstruments(MetaBrainz.MusicBrainz.Interfaces.Entities.ICollection collection, int? pageSize = default, int? offset = default, Include inc = Include.None);


### PR DESCRIPTION
This uses both the text form (non-paged result, `GetAllGenreNames[Async]`) and the JSON form (normal paged browse result, `BrowseAllGenres[Async]`).

Fixes #65.