### PR TITLE
Allow more Genre information

### DIFF
--- a/MetaBrainz.MusicBrainz/Include.cs
+++ b/MetaBrainz.MusicBrainz/Include.cs
@@ -158,6 +158,9 @@ public enum Include : long {
   /// </remarks>
   ReleaseGroupLevelRelationships = 1L << 54,
 
+  /// <summary>Include information about relationships with genres.</summary>
+  GenreRelationships = 1L << 55,
+
   #endregion
 
 }

--- a/MetaBrainz.MusicBrainz/Objects/Browses/BrowseGenres.cs
+++ b/MetaBrainz.MusicBrainz/Objects/Browses/BrowseGenres.cs
@@ -7,7 +7,8 @@ namespace MetaBrainz.MusicBrainz.Objects.Browses;
 
 internal sealed class BrowseGenres : BrowseResults<IGenre> {
 
-  public BrowseGenres(Query query, int? limit, int? offset) : base(query, "genre", "all", null, limit, offset) {
+  public BrowseGenres(Query query, IReadOnlyDictionary<string, string> options, int? limit,
+                      int? offset) : base(query, "genre", "all", options, limit, offset) {
   }
 
   public override IReadOnlyList<IGenre> Results => this.CurrentResult?.Genres ?? Array.Empty<IGenre>();

--- a/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
+++ b/MetaBrainz.MusicBrainz/Query.Browse.Genres.cs
@@ -14,11 +14,13 @@ public sealed partial class Query {
   /// <summary>Returns (the specified subset of) the genres known to MusicBrainz.</summary>
   /// <param name="limit">The maximum number of results to return (1-100; default is 25).</param>
   /// <param name="offset">The offset at which to start (i.e. the number of results to skip).</param>
+  /// <param name="inc">Additional information to include in the result.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The browse request, including the initial results.</returns>
   public Task<IBrowseResults<IGenre>> BrowseAllGenresAsync(int? limit = null, int? offset = null,
+                                                           Include inc = Include.None,
                                                            CancellationToken cancellationToken = default)
-    => new BrowseGenres(this, limit, offset).NextAsync(cancellationToken);
+    => new BrowseGenres(this, Query.CreateOptions(inc), limit, offset).NextAsync(cancellationToken);
 
   /// <summary>Gets the names of all genres known to MusicBrainz.</summary>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>

--- a/MetaBrainz.MusicBrainz/Query.Internals.cs
+++ b/MetaBrainz.MusicBrainz/Query.Internals.cs
@@ -138,6 +138,9 @@ public sealed partial class Query : IDisposable {
     if ((inc & Include.EventRelationships) != 0) {
       included.Add("event-rels");
     }
+    if ((inc & Include.GenreRelationships) != 0) {
+      included.Add("genre-rels");
+    }
     if ((inc & Include.InstrumentRelationships) != 0) {
       included.Add("instrument-rels");
     }

--- a/MetaBrainz.MusicBrainz/Query.Lookup.cs
+++ b/MetaBrainz.MusicBrainz/Query.Lookup.cs
@@ -96,12 +96,13 @@ public sealed partial class Query {
 
   /// <summary>Looks up the specified genre.</summary>
   /// <param name="mbid">The MBID for the genre to look up.</param>
+  /// <param name="inc">Additional information to include in the result.</param>
   /// <param name="cancellationToken">The cancellation token to cancel the operation.</param>
   /// <returns>The requested genre.</returns>
   /// <exception cref="HttpError">When the web service reports an error.</exception>
   /// <exception cref="HttpRequestException">When something goes wrong with the request.</exception>
-  public async Task<IGenre> LookupGenreAsync(Guid mbid, CancellationToken cancellationToken = default)
-    => await this.PerformRequestAsync<Genre>("genre", mbid, null, cancellationToken).ConfigureAwait(false);
+  public async Task<IGenre> LookupGenreAsync(Guid mbid, Include inc = Include.None, CancellationToken cancellationToken = default)
+    => await this.PerformRequestAsync<Genre>("genre", mbid, Query.CreateOptions(inc), cancellationToken).ConfigureAwait(false);
 
   /// <summary>Looks up the specified instrument.</summary>
   /// <param name="mbid">The MBID for the instrument to look up.</param>

--- a/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
+++ b/public-api/MetaBrainz.MusicBrainz.net8.0.cs.md
@@ -67,6 +67,7 @@ public enum Include : long {
   Collections = 0x00000000000002,
   DiscIds = 0x00000000020000,
   EventRelationships = 0x00040000000000,
+  GenreRelationships = 0x80000000000000,
   Genres = 0x00000400000000,
   InstrumentRelationships = 0x00080000000000,
   Isrcs = 0x00000000040000,
@@ -620,7 +621,7 @@ public sealed class Query : System.IDisposable {
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IEvent> BrowseAllEvents(MetaBrainz.MusicBrainz.Interfaces.Entities.IPlace place, int? pageSize = default, int? offset = default, Include inc = Include.None);
 
-  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre>> BrowseAllGenresAsync(int? limit = default, int? offset = default, System.Threading.CancellationToken cancellationToken = default);
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Browses.IBrowseResults<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre>> BrowseAllGenresAsync(int? limit = default, int? offset = default, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);
 
   public MetaBrainz.MusicBrainz.Interfaces.IStreamingQueryResults<MetaBrainz.MusicBrainz.Interfaces.Entities.ICollection> BrowseAllInstrumentCollections(System.Guid mbid, int? pageSize = default, int? offset = default);
 
@@ -974,7 +975,7 @@ public sealed class Query : System.IDisposable {
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IEvent> LookupEventAsync(System.Guid mbid, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);
 
-  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre> LookupGenreAsync(System.Guid mbid, System.Threading.CancellationToken cancellationToken = default);
+  public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IGenre> LookupGenreAsync(System.Guid mbid, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);
 
   public System.Threading.Tasks.Task<MetaBrainz.MusicBrainz.Interfaces.Entities.IInstrument> LookupInstrumentAsync(System.Guid mbid, Include inc = Include.None, System.Threading.CancellationToken cancellationToken = default);
 


### PR DESCRIPTION
This prepares for [MBS-12368](https://tickets.metabrainz.org/browse/MBS-12368) by adding an `inc` argument to genre lookups and browses, and adding `GenreRelationships` to the `Include` enum.

The current server does not do anything for such requests yet, so `IGenre` has not yet been extended with the additional information.